### PR TITLE
Interactive session creation, expanded headers

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -34,16 +34,21 @@ handle_output() {
 BIND_CTRL_D="ctrl-d:execute(tmux kill-session -t {})+reload(tmux list-sessions | sed -E 's/:.*$//' | grep -v $(tmux display-message -p '#S'))"
 BIND_CTRL_W="ctrl-w:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -w {} | bat --style plain)"
 BIND_CTRL_O="ctrl-o:print-query+execute(tmux new-session -d -s {})"
+BIND_CTRL_N='ctrl-n:execute(printf >&2 "Session name: ";read name; tmux new-session -d -s ${name}; tmux choose-tree attach-session -t ${name})+reload(tmux list-sessions | sed -E "s/:.*$//")'
 CTRL_X_PATH=$(tmux_option_or_fallback "@sessionx-x-path" "$HOME/.config")
 BIND_CTRL_X="ctrl-x:reload(find $CTRL_X_PATH -mindepth 1 -maxdepth 1 -type d)"
 BIND_ENTER="enter:replace-query+print-query"
 BIND_CTRL_R='ctrl-r:execute(printf >&2 "New name: ";read name; tmux rename-session -t {} ${name};)+reload(tmux list-sessions | sed -E "s/:.*$//")'
 
+HEADER="󰿄=go 
+C-d=del C-r=rename C-x=custom 
+C-w=window-mode C-n=new session"
+
 RESULT=$(input | \
     fzf-tmux \
         -p "75%,75%" \
 	--prompt " " \
-        --header='󰿄=go C-d=del C-r=rename C-x=custom C-w=window-mode' \
+    --header="$HEADER" \
 	--print-query \
         --border-label "Current session: \"$CURRENT\" " \
         --bind "$BIND_CTRL_D" \
@@ -51,6 +56,7 @@ RESULT=$(input | \
         --bind "$BIND_CTRL_X" \
         --bind "$BIND_CTRL_R" \
         --bind "$BIND_CTRL_W" \
+        --bind "$BIND_CTRL_N" \
         --bind "$BIND_ENTER" \
         --exit-0 \
         --preview="${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh {} | bat --style plain" \


### PR DESCRIPTION
Hi there, 

Big fan of the plugin, I found myself wanting to create new sessions interactively so I ended up adding another binding, I know C-o will do the trick but I don't always need to jump to the session immediately.

I appreciate that  this is most likely used for your own workflow but leaving as a pull request in case someone wants the feature.
