### PR TITLE
🚀 New Bind keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ set -g @sessionx-bind '<mykey>'
 ```
 ### Additional configuration options:
 ```bash
-# `C-x` is a customizeable, by default it indexes directories in `$HOME/.config`, 
+# `C-x` is a customizeable, by default it indexes directories in `$HOME/.config`,
 # but this can be changed by adding the config below.
 # e.g. set -g @sessionx-x-path '~/dotfiles'
 set -g @sessionx-x-path '<some-path>'
 
-# A comma delimited absolute-paths list of custom paths 
-# always visible in results and ready to create a session from. 
+# A comma delimited absolute-paths list of custom paths
+# always visible in results and ready to create a session from.
 # Tip: if you're using zoxide mode, there's a good chance this is redundant
 set -g @sessionx-custom-paths '/Users/me/projects,/Users/me/second-brain'
 
@@ -40,11 +40,11 @@ set -g @sessionx-custom-paths '/Users/me/projects,/Users/me/second-brain'
 # This is to support quick switch of sessions
 # Only after other actions (e.g. rename) will the current session appear
 # Setting this option to 'false' changes this default behavior
-set -g @sessionx-filter-current 'false' 
+set -g @sessionx-filter-current 'false'
 
 # Window mode can be turned on so that the default layout
 # Has all the windows listed rather than sessions only
-set -g @sessionx-window-mode 'on' 
+set -g @sessionx-window-mode 'on'
 
 # Preview location and screenspace can be adjusted with these
 # Reminder: it can be toggeled on/off with `?`
@@ -62,6 +62,58 @@ set -g @sessionx-zoxide-mode 'on'
 # If you're running fzf lower than 0.35.0 there are a few missing features
 # Upgrade, or use this setting for support
 set -g @sessionx-legacy-fzf-support 'on'
+```
+
+### Bind keys:
+If you want to change the default key bindings, you can do using this configuration options:
+```bash
+# Configuring Key Bindings:
+# I've remapped these commands to 'alt'.
+# To modify default key bindings, you can use these configuration options:
+
+# This command is equivalent to the 'Enter' key.
+set -g @sessionx-bind-accept 'alt-j'
+
+# This command opens the current window list.
+# By default, it is set to `C-w`.
+set -g @sessionx-bind-window-mode 'alt-s'
+
+# This command opens the tree.
+# By default, it is set to `C-t`.
+set -g @sessionx-bind-tree-mode 'alt-w'
+
+# This command opens the configuration path.
+# By default, it is set to `C-x`.
+set -g @sessionx-bind-new-window 'alt-c'
+
+# By default, it is set to `C-r`.
+set -g @sessionx-bind-read 'alt-r'
+
+# This command rebinds scrolling up/down inside the preview.
+set -g @sessionx-bind-scroll-up 'alt-m'
+set -g @sessionx-bind-scroll-down 'alt-n'
+
+# Sessionx Commands:
+# These commands are used within sessionx when it's open.
+
+# This command is equivalent to killing the selected session.
+set -g @sessionx-bind-kill-session 'alt-x'
+
+# This command opens the configuration path.
+set -g @sessionx-bind-configuration-path 'alt-e'
+
+# This command goes back to the previous command.
+set -g @sessionx-bind-back 'alt-h'
+
+# These commands are bindings to select arrows.
+set -g @sessionx-bind-select-up 'alt-l'
+set -g @sessionx-bind-select-down 'alt-k'
+
+# These commands are bindings to delete characters.
+set -g @sessionx-bind-delete-char 'alt-p'
+
+# These commands are bindings to exit sessionx.
+set -g @sessionx-bind-abort 'alt-q'
 ```
 
 ## Working with SessionX 👷


### PR DESCRIPTION
# Introducing New Options for Key Rebinding
I prefer using bindkeys with the `Alt` key modifier, so I've made alterations to the commands. 
Additionally, I've incorporated several commands to bind keys within the application.

1. Renamed functions from `handle_args()` to better reflect their respective modes.
2. Implemented the `handle_binds()` method in scripts/sessionx.
3. Updated `HEADER` to display the bindkey variables.
4. Included new options for selecting, exiting, deleting, and accepting within sessionx.

## Test Plan
1. Open your `tmux.conf` and place these commands:
```bash
set -g @sessionx-bind-accept 'alt-j'

set -g @sessionx-bind-window-mode 'alt-s'
set -g @sessionx-bind-tree-mode 'alt-w'
set -g @sessionx-bind-new-window 'alt-c'

set -g @sessionx-bind-kill-session 'alt-x'
set -g @sessionx-bind-configuration-path 'alt-e'
set -g @sessionx-bind-back 'alt-h'
set -g @sessionx-bind-exit 'alt-q'
set -g @sessionx-bind-scroll-up 'alt-m'
set -g @sessionx-bind-scroll-down 'alt-n'

set -g @sessionx-bind-select-up 'alt-l'
set -g @sessionx-bind-select-down 'alt-k'

set -g @sessionx-bind-delete-char 'alt-p'
set -g @sessionx-bind-abort 'alt-q'
```
2. Open the sessionx and see if it is working correctly 


## Checklist

- [ ] Tests updated
- [x] Docs updated

## Screenshots
![image](https://github.com/omerxx/tmux-sessionx/assets/108758883/2930e77c-3789-46da-bc6c-1a003365c179)