### PR TITLE
stop using "--scrollbar" for legacy fzf

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -122,13 +122,13 @@ handle_args() {
         --prompt " " \
         --print-query \
         --tac \
-        --scrollbar '▌▐'\
         )
 
     legacy=$(tmux_option_or_fallback "@sessionx-legacy-fzf-support" "off")
     if [[ "${legacy}" == "off" ]]; then
         args+=(--border-label "Current session: \"$CURRENT\" ")
         args+=(--bind 'focus:transform-preview-label:echo [ {} ]')
+        args+=(--scrollbar '▌▐')
     fi
 
 }


### PR DESCRIPTION
Turns out that fzf 0.29 doesn't like the option and refuses to work.