### PR TITLE
Fixes: The icon is overlapping with the text (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ set -g @sessionx-layout 'reverse'
 
 # If you want to change the prompt
 set -g @sessionx-prompt ''
+# If you want to change the prompt, the space is nedded to not overlap the icon
+set -g @sessionx-prompt " "
 
 # If you want to change the pointer
-set -g @sessionx-pointer '▶'
+set -g @sessionx-pointer "▶ "
 
 # When set to 'on' a non-result will be sent to zoxide for path matching
 # Requires zoxide installed

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -169,7 +169,7 @@ handle_args() {
         --layout="$layout_mode" \
         --pointer=$pointer_icon \
         -p "$window_width,$window_height" \
-        --prompt $prompt_icon \
+        --prompt "$prompt_icon" \
         --print-query \
         --tac \
         --scrollbar '▌▐'\


### PR DESCRIPTION
The icon is overlapping with the text. It was reported yesterday (Issue #48). I experienced the same problem and here is the fix.

Comment: Quite subtle issue, but quite fun the debug.