### PR TITLE
Fix rename in fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ set -g @sessionx-bind-tree-mode 'alt-w'
 set -g @sessionx-bind-new-window 'alt-c'
 
 # By default, it is set to `C-r`.
-set -g @sessionx-bind-kill-session 'alt-r'
+set -g @sessionx-bind-rename-session 'alt-r'
 
 # This command rebinds scrolling up/down inside the preview.
 set -g @sessionx-bind-scroll-up 'alt-m'

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ set -g @sessionx-window-width '75%'
 # If you want change the layout to top you can set
 set -g @sessionx-layout 'reverse'
 
-# If you want to change the prompt
-set -g @sessionx-prompt ''
 # If you want to change the prompt, the space is nedded to not overlap the icon
 set -g @sessionx-prompt " "
 
@@ -106,7 +104,7 @@ set -g @sessionx-bind-tree-mode 'alt-w'
 set -g @sessionx-bind-new-window 'alt-c'
 
 # By default, it is set to `C-r`.
-set -g @sessionx-bind-read 'alt-r'
+set -g @sessionx-bind-kill-session 'alt-r'
 
 # This command rebinds scrolling up/down inside the preview.
 set -g @sessionx-bind-scroll-up 'alt-m'

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -139,7 +139,9 @@ handle_args() {
     SCROLL_UP="$bind_scroll_up:preview-half-page-up"
     SCROLL_DOWN="$bind_scroll_down:preview-half-page-down"
 
-    RENAME_SESSION='ctrl-r:execute(printf >&2 "New name: ";read name; tmux rename-session -t {} ${name};)+reload(tmux list-sessions | sed -E "s/:.*$//")'
+    RENAME_SESSION_EXEC='bash -c '\'' printf >&2 "New name: ";read name; tmux rename-session -t {} ${name}; '\'''
+    RENAME_SESSION_RELOAD='bash -c '\'' tmux list-sessions | sed -E "s/:.*$//"; '\'''
+    RENAME_SESSION="ctrl-r:execute($RENAME_SESSION_EXEC)+reload($RENAME_SESSION_RELOAD)"
 
     HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  C-r=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= "
 

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -38,6 +38,7 @@ handle_binds() {
   bind_tree_mode=$(tmux_option_or_fallback "@sessionx-bind-tree-mode" "ctrl-t")
   bind_window_mode=$(tmux_option_or_fallback "@sessionx-bind-window-mode" "ctrl-w")
   bind_configuration_mode=$(tmux_option_or_fallback "@sessionx-bind-configuration-path" "ctrl-x")
+  bind_rename_session=$(tmux_option_or_fallback "@sessionx-bind-rename-session" "ctrl-r")
 
   bind_back=$(tmux_option_or_fallback "@sessionx-bind-back" "ctrl-b")
   bind_new_window=$(tmux_option_or_fallback "@sessionx-bind-new-window" "ctrl-e")
@@ -141,9 +142,9 @@ handle_args() {
 
     RENAME_SESSION_EXEC='bash -c '\'' printf >&2 "New name: ";read name; tmux rename-session -t {} ${name}; '\'''
     RENAME_SESSION_RELOAD='bash -c '\'' tmux list-sessions | sed -E "s/:.*$//"; '\'''
-    RENAME_SESSION="ctrl-r:execute($RENAME_SESSION_EXEC)+reload($RENAME_SESSION_RELOAD)"
+    RENAME_SESSION="$bind_rename_session:execute($RENAME_SESSION_EXEC)+reload($RENAME_SESSION_RELOAD)"
 
-    HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  C-r=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= "
+    HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  $bind_rename_session=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= "
 
 
     args=(


### PR DESCRIPTION
Hi, this should fix #20
The problem is that:
1. fish's read behaves differently than bash's, it probably fails because it doesn't have access to stdin?
2. when it sees a $ it errors because there is no variable $, I guess bash just lets you do whatever and passes the $ as is.

Anyways, fish has a lot of quirks so I don't think it's worth trying to make it work for it, just make it use bash always with `bash -c ...`.

I tested it in fish and bash and it works as expected.