### PR TITLE
stops removing spaces from session names

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -70,23 +70,22 @@ input() {
 }
 
 additional_input() {
+
     sessions=$(tmux list-sessions | sed -E 's/:.*$//')
     custom_paths=$(tmux_option_or_fallback "@sessionx-custom-paths" "")
     list=()
     if [[ -z "$custom_paths" ]]; then
         echo ""
     else
-        for i in ${custom_paths//,/ }; do
+        clean_paths=$(echo $custom_paths | sed -E 's/ *, */,/g' | sed -E 's/^ *//' | sed -E 's/ *$//' | sed  -E 's/ /✗/g' )
+        for i in ${clean_paths//,/$IFS}; do
             if [[ $sessions == *"${i##*/}"* ]]; then
                 continue
-              fi
-              list+=("${i}\n")
-            last=$i
+            fi
+            echo $i
         done
-        unset 'list[${#list[@]}-1]'
-        list+=("${last}")
-        echo "${list[@]}"
     fi
+
 }
 
 handle_output() {
@@ -191,7 +190,7 @@ run_plugin() {
     window_settings
     handle_binds
     handle_args
-    RESULT=$(echo -e "${INPUT// /}" | fzf-tmux "${args[@]}")
+    RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${args[@]}")
 }
 
 run_plugin

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -137,7 +137,7 @@ handle_args() {
     SCROLL_UP="$bind_scroll_up:preview-half-page-up"
     SCROLL_DOWN="$bind_scroll_down:preview-half-page-down"
 
-    RENAME_SESSION_EXEC='bash -c '\'' printf >&2 "New name: ";read name; tmux rename-session -t {} ${name}; '\'''
+    RENAME_SESSION_EXEC='bash -c '\'' printf >&2 "New name: ";read name; tmux rename-session -t {1} "${name}"; '\'''
     RENAME_SESSION_RELOAD='bash -c '\'' tmux list-sessions | sed -E "s/:.*$//"; '\'''
     RENAME_SESSION="$bind_rename_session:execute($RENAME_SESSION_EXEC)+reload($RENAME_SESSION_RELOAD)"
 

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -70,7 +70,6 @@ input() {
 }
 
 additional_input() {
-
     sessions=$(tmux list-sessions | sed -E 's/:.*$//')
     custom_paths=$(tmux_option_or_fallback "@sessionx-custom-paths" "")
     list=()
@@ -85,7 +84,6 @@ additional_input() {
             echo $i
         done
     fi
-
 }
 
 handle_output() {


### PR DESCRIPTION
- Git log research: I think the space removal came about in a commit with the message "additional input for custom paths" and effectively has been in place since that feature was added. Commit: 5107ae06e0a175d68816ff081cc186214306c064

- I think the intent was to remove spaces because of a bug in additional_input. It didn't iterate over the list of options and the for loop ran once no matter what (for me at least).

I'm wondering why the additional_input method was so complicated, so maybe I'm missing something.

Fixes #38 