### PR TITLE
Add fzf options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ set -g @sessionx-pointer "▶ "
 # Requires zoxide installed
 set -g @sessionx-zoxide-mode 'on'
 
+# If you want to pass in your own FZF options. This is passed in before all other
+# arguments to FZF to ensure that other options like `sessionx-pointer` and 
+# `sessionx-window-height/width` still work. See `man fzf` for config options.
+set -g @sessionx-fzf-options "--color 'pointer:9,spinner:92,marker:46'"
+
 # If you're running fzf lower than 0.35.0 there are a few missing features
 # Upgrade, or use this setting for support
 set -g @sessionx-legacy-fzf-support 'on'

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ set -g @sessionx-zoxide-mode 'on'
 # If you want to pass in your own FZF options. This is passed in before all other
 # arguments to FZF to ensure that other options like `sessionx-pointer` and 
 # `sessionx-window-height/width` still work. See `man fzf` for config options.
-set -g @sessionx-fzf-options "--color pointer:9,spinner:92,marker:46"
+set -g @sessionx-additional-options "--color pointer:9,spinner:92,marker:46"
 
 # If you're running fzf lower than 0.35.0 there are a few missing features
 # Upgrade, or use this setting for support

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ set -g @sessionx-zoxide-mode 'on'
 # If you want to pass in your own FZF options. This is passed in before all other
 # arguments to FZF to ensure that other options like `sessionx-pointer` and 
 # `sessionx-window-height/width` still work. See `man fzf` for config options.
-set -g @sessionx-fzf-options "--color 'pointer:9,spinner:92,marker:46'"
+set -g @sessionx-fzf-options "--color pointer:9,spinner:92,marker:46"
 
 # If you're running fzf lower than 0.35.0 there are a few missing features
 # Upgrade, or use this setting for support

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -54,7 +54,6 @@ handle_binds() {
   bind_select_up=$(tmux_option_or_fallback "@sessionx-bind-select-up" "ctrl-n")
   bind_select_down=$(tmux_option_or_fallback "@sessionx-bind-select-down" "ctrl-m")
 
-  fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color pointer:9,spinner:92,marker:46")
 }
 
 input() {
@@ -150,7 +149,6 @@ handle_args() {
 
 
     args=(
-        $fzf_options \
         --bind "$TREE_MODE" \
         --bind "$CONFIGURATION_MODE" \
         --bind "$WINDOWS_MODE" \
@@ -186,6 +184,8 @@ handle_args() {
         args+=(--bind 'focus:transform-preview-label:echo [ {} ]')
     fi
 
+    additional_fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color pointer:9,spinner:92,marker:46")
+    eval "fzf_opts=($additional_fzf_options)"
 }
 
 run_plugin() {
@@ -193,7 +193,7 @@ run_plugin() {
     window_settings
     handle_binds
     handle_args
-    RESULT=$(echo -e "${INPUT// /}" | fzf-tmux "${args[@]}")
+    RESULT=$(echo -e "${INPUT// /}" | fzf-tmux "$fzf_opts[@] $args[@]")
 }
 
 run_plugin

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -39,7 +39,7 @@ handle_binds() {
   bind_window_mode=$(tmux_option_or_fallback "@sessionx-bind-window-mode" "ctrl-w")
   bind_configuration_mode=$(tmux_option_or_fallback "@sessionx-bind-configuration-path" "ctrl-x")
   bind_rename_session=$(tmux_option_or_fallback "@sessionx-bind-rename-session" "ctrl-r")
-	additional_fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color pointer:9,spinner:92,marker:46")
+  additional_fzf_options=$(tmux_option_or_fallback "@sessionx-additional-options" "--color pointer:9,spinner:92,marker:46")
 
   bind_back=$(tmux_option_or_fallback "@sessionx-bind-back" "ctrl-b")
   bind_new_window=$(tmux_option_or_fallback "@sessionx-bind-new-window" "ctrl-e")

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -39,7 +39,7 @@ handle_binds() {
   bind_window_mode=$(tmux_option_or_fallback "@sessionx-bind-window-mode" "ctrl-w")
   bind_configuration_mode=$(tmux_option_or_fallback "@sessionx-bind-configuration-path" "ctrl-x")
   bind_rename_session=$(tmux_option_or_fallback "@sessionx-bind-rename-session" "ctrl-r")
-  additional_fzf_options=$(tmux_option_or_fallback "@sessionx-additional-options" "--color pointer:9,spinner:92,marker:46")
+	additional_fzf_options=$(tmux_option_or_fallback "@sessionx-additional-options" "")
 
   bind_back=$(tmux_option_or_fallback "@sessionx-bind-back" "ctrl-b")
   bind_new_window=$(tmux_option_or_fallback "@sessionx-bind-new-window" "ctrl-e")

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -39,6 +39,7 @@ handle_binds() {
   bind_window_mode=$(tmux_option_or_fallback "@sessionx-bind-window-mode" "ctrl-w")
   bind_configuration_mode=$(tmux_option_or_fallback "@sessionx-bind-configuration-path" "ctrl-x")
   bind_rename_session=$(tmux_option_or_fallback "@sessionx-bind-rename-session" "ctrl-r")
+	additional_fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color pointer:9,spinner:92,marker:46")
 
   bind_back=$(tmux_option_or_fallback "@sessionx-bind-back" "ctrl-b")
   bind_new_window=$(tmux_option_or_fallback "@sessionx-bind-new-window" "ctrl-e")
@@ -184,8 +185,7 @@ handle_args() {
         args+=(--bind 'focus:transform-preview-label:echo [ {} ]')
     fi
 
-    additional_fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color pointer:9,spinner:92,marker:46")
-    eval "fzf_opts=($additional_fzf_options)"
+	eval "fzf_opts=($additional_fzf_options)"
 }
 
 run_plugin() {
@@ -193,7 +193,7 @@ run_plugin() {
     window_settings
     handle_binds
     handle_args
-    RESULT=$(echo -e "${INPUT// /}" | fzf-tmux "$fzf_opts[@] $args[@]")
+	RESULT=$(echo -e "${INPUT// /}" | fzf-tmux "${fzf_opts[@]}" "${args[@]}")
 }
 
 run_plugin

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -54,7 +54,7 @@ handle_binds() {
   bind_select_up=$(tmux_option_or_fallback "@sessionx-bind-select-up" "ctrl-n")
   bind_select_down=$(tmux_option_or_fallback "@sessionx-bind-select-down" "ctrl-m")
 
-  fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color 'pointer:9,spinner:92,marker:46'" )
+  fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color pointer:9,spinner:92,marker:46")
 }
 
 input() {

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -53,6 +53,8 @@ handle_binds() {
 
   bind_select_up=$(tmux_option_or_fallback "@sessionx-bind-select-up" "ctrl-n")
   bind_select_down=$(tmux_option_or_fallback "@sessionx-bind-select-down" "ctrl-m")
+
+  fzf_options=$(tmux_option_or_fallback "@sessionx-fzf-options" "--color 'pointer:9,spinner:92,marker:46'" )
 }
 
 input() {
@@ -148,6 +150,7 @@ handle_args() {
 
 
     args=(
+        $fzf_options \
         --bind "$TREE_MODE" \
         --bind "$CONFIGURATION_MODE" \
         --bind "$WINDOWS_MODE" \
@@ -164,7 +167,6 @@ handle_args() {
         --bind "$RENAME_SESSION" \
         --bind '?:toggle-preview' \
         --bind 'change:first' \
-        --color 'pointer:9,spinner:92,marker:46' \
         --exit-0 \
         --header="$HEADER" \
         --preview="${PREVIEW_LINE}" \


### PR DESCRIPTION
This PR adds a binding to be able to pass in FZF options, addressing #54. I put them first in the list of arguments so that any options that are core to the plugin functionality or already exist as separate bindings will override user-provided options, preventing the user from breaking the plugin.