### PR TITLE
Fixes: Naming in window mode (#60)

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -58,7 +58,7 @@ handle_binds() {
 input() {
     default_window_mode=$(tmux_option_or_fallback "@sessionx-window-mode" "off")
     if [[ "$default_window_mode" == "on" ]]; then
-        (tmux list-windows -a -F '#{session_name}:#{window_index}')
+        (tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}')
     else
         filter_current_session=$(tmux_option_or_fallback "@sessionx-filter-current" "true")
         if [[ "$filter_current_session" == "true" ]]; then
@@ -90,7 +90,8 @@ additional_input() {
 }
 
 handle_output() {
-    target=$(echo "$1" | tr -d '\n')
+    args=($1)
+    target=$(echo "${args[0]}" | tr -d '\n')
     if [[ -z "$target" ]]; then
         exit 0
     fi
@@ -191,7 +192,7 @@ run_plugin() {
     window_settings
     handle_binds
     handle_args
-    RESULT=$(echo -e "${INPUT// /}" | fzf-tmux "${args[@]}")
+    RESULT=$(echo -e "${INPUT}" | fzf-tmux "${args[@]}")
 }
 
 run_plugin


### PR DESCRIPTION
Window names are not shown (issue #60), this show it as "<session_name>:<window_id> <window_name>" and so it makes it fuzzy searchable.