### PR TITLE
fix window name spacing in result

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -193,7 +193,7 @@ run_plugin() {
 	window_settings
 	handle_binds
 	handle_args
-	RESULT=$(echo -e "${INPUT// /}" | fzf-tmux "${fzf_opts[@]}" "${args[@]}")
+	RESULT=$(echo -e "${INPUT}" | fzf-tmux "${fzf_opts[@]}" "${args[@]}")
 }
 
 run_plugin


### PR DESCRIPTION
Seems latest commits broke the window name display in the result lite, this is due to replacing all "spaces" from the `INPUT`

Is there a case where spaces is not allowed in the `INPUT` 🤔 ? I can't see it.

If not allowing space in the `INPUT` then preview and selection do not work when in window mode.