### PR TITLE
Tmuxinator intergration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ set -g @sessionx-additional-options "--color pointer:9,spinner:92,marker:46"
 # If you're running fzf lower than 0.35.0 there are a few missing features
 # Upgrade, or use this setting for support
 set -g @sessionx-legacy-fzf-support 'on'
+
+# With Tmuxinaor turned 'on' (off by default), the plugin will take a given name
+# and look for a tmuxinator project with that name. 
+# If found, it'll launch the template using tmuxinator
+set -g @sessionx-tmuxinator-mode 'off'
 ```
 
 ## Working with SessionX 👷
@@ -106,6 +111,7 @@ If you insert a non-existing name and hit enter, a new session with that name wi
 - `Ctrl-e` "expand": will expand `PWD` and search for local directories to create additional session from
 - `Ctrl-b` "back": reloads the first query. Useful when going into window or expand mode, to go back
 - `Ctrl-t` "tree": reloads the preview with the tree of sessions+windows familiar from the native session manager (C-S)
+- `Ctrl-/` "tmuxinator": fetches a list of tmuxinator sessions and previews them
 - `?` toggles the preview pane
 
 ### Rebind keys:
@@ -160,7 +166,20 @@ set -g @sessionx-bind-delete-char 'alt-p'
 
 # These commands are bindings to exit sessionx.
 set -g @sessionx-bind-abort 'alt-q'
+
+# This command opens the tmuxinator list.
+set -g @sessionx-bind-tmuxinator-list 'alt-t'
 ```
+
+## Tmuxinator Integration 🚀
+
+If you want sessionx to detect existing tmuxinator projects, you can set `@sessionx-tmuxinator-mode 'on'` in your config. 
+With Tmuxinaor turned 'on' (off by default), the plugin will take a given name and look for a tmuxinator project with that name. If found, it'll **launch the template using tmuxinator**!.
+There's also a binding to list tmuxinator projects, defaulting to `Ctrl-/`, configurable via:
+```bash
+set -g @sessionx-bind-tmuxinator-list 'alt-t'
+```
+
 
 ## WARNING ⚠️
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ set -g @sessionx-bind-abort 'alt-q'
 set -g @sessionx-bind-tmuxinator-list 'alt-t'
 ```
 
-## Tmuxinator Integration 🚀
+## [Tmuxinator](https://github.com/tmuxinator/tmuxinator) Integration 🚀
 
 If you want sessionx to detect existing tmuxinator projects, you can set `@sessionx-tmuxinator-mode 'on'` in your config. 
 With Tmuxinaor turned 'on' (off by default), the plugin will take a given name and look for a tmuxinator project with that name. If found, it'll **launch the template using tmuxinator**!.

--- a/README.md
+++ b/README.md
@@ -173,10 +173,14 @@ set -g @sessionx-bind-tmuxinator-list 'alt-t'
 
 ## [Tmuxinator](https://github.com/tmuxinator/tmuxinator) Integration 🚀
 
-If you want sessionx to detect existing tmuxinator projects, you can set `@sessionx-tmuxinator-mode 'on'` in your config. 
+If you want sessionx to detect existing tmuxinator projects, you can set a `sessionx-tmuxinator-mode` in your config (see snippet below). 
 With Tmuxinaor turned 'on' (off by default), the plugin will take a given name and look for a tmuxinator project with that name. If found, it'll **launch the template using tmuxinator**!.
 There's also a binding to list tmuxinator projects, defaulting to `Ctrl-/`, configurable via:
 ```bash
+# Tmuxinator mode on
+set -g @sessionx-tmuxinator-mode 'on'
+
+# Changing the binding from the default Ctrl-/
 set -g @sessionx-bind-tmuxinator-list 'alt-t'
 ```
 

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -77,22 +77,21 @@ input() {
 additional_input() {
 	sessions=$(tmux list-sessions | sed -E 's/:.*$//')
 	custom_paths=$(tmux_option_or_fallback "@sessionx-custom-paths" "")
-	list=()
 	if [[ -z "$custom_paths" ]]; then
 		echo ""
 	else
-		clean_paths=$(echo $custom_paths | sed -E 's/ *, */,/g' | sed -E 's/^ *//' | sed -E 's/ *$//' | sed	-E 's/ /✗/g' )
+		clean_paths=$(echo "$custom_paths" | sed -E 's/ *, */,/g' | sed -E 's/^ *//' | sed -E 's/ *$//' | sed -E 's/ /✗/g')
 		for i in ${clean_paths//,/$IFS}; do
 			if [[ $sessions == *"${i##*/}"* ]]; then
 				continue
 			fi
-			echo $i
+			echo "$i"
 		done
 	fi
 }
 
 handle_output() {
-	if [ -d "$@" ]; then
+	if [ -d "$*" ]; then
 		# No special handling because there isn't a window number or window name present
 		# except in unlikely and contrived situations (e.g.
 		# "/home/person/projects:0\ bash" could be a path on your filesystem.)

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -37,6 +37,7 @@ window_settings() {
 }
 
 handle_binds() {
+	bind_tmuxinator_list=$(tmux_option_or_fallback "@sessionx-bind-tmuxinator-list" "ctrl-/")
 	bind_tree_mode=$(tmux_option_or_fallback "@sessionx-bind-tree-mode" "ctrl-t")
 	bind_window_mode=$(tmux_option_or_fallback "@sessionx-bind-window-mode" "ctrl-w")
 	bind_configuration_mode=$(tmux_option_or_fallback "@sessionx-bind-configuration-path" "ctrl-x")
@@ -111,7 +112,9 @@ handle_output() {
 	fi
 
 	if ! tmux has-session -t="$target" 2>/dev/null; then
-		if test -d "$target"; then
+		if is_known_tmuxinator_template "$target"; then
+			tmuxinator start "$target"
+		elif test -d "$target"; then
 			tmux new-session -ds "${target##*/}" -c "$target"
 			target="${target##*/}"
 		else
@@ -138,6 +141,7 @@ handle_args() {
 	Z_MODE=$(tmux_option_or_fallback "@sessionx-zoxide-mode" "off")
 	CONFIGURATION_PATH=$(tmux_option_or_fallback "@sessionx-x-path" "$HOME/.config")
 
+	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml)"
 	TREE_MODE="$bind_tree_mode:change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -t {1})"
 	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d)+change-preview(ls {})"
 	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_index}')+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -w {1})"
@@ -162,6 +166,7 @@ handle_args() {
 	HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  $bind_rename_session=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= "
 
 	args=(
+		--bind "$TMUXINATOR_MODE"
 		--bind "$TREE_MODE"
 		--bind "$CONFIGURATION_MODE"
 		--bind "$WINDOWS_MODE"

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -3,6 +3,8 @@
 CURRENT="$(tmux display-message -p '#S')"
 Z_MODE="off"
 
+source scripts/tmuxinator.sh
+
 tmux_option_or_fallback() {
 	local option_value
 	option_value="$(tmux show-option -gqv "$1")"

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+is_known_tmuxinator_template() {
+	tmuxinator list | grep -q "^$1$"
+}


### PR DESCRIPTION
This PR adds support for https://github.com/tmuxinator/tmuxinator:

- Adds bindings to list existing projects and preview that (with `cat` ATM), defaults to `Ctrl-/`
- Adds a `tmuxinator_mode` (off by default), which, if turned on, detects the given session name and if it is found as an existing tmuxinator project, launches it