### PR TITLE
List tmuxinator projects with `--newline`

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -140,7 +140,7 @@ handle_args() {
 	Z_MODE=$(tmux_option_or_fallback "@sessionx-zoxide-mode" "off")
 	CONFIGURATION_PATH=$(tmux_option_or_fallback "@sessionx-x-path" "$HOME/.config")
 
-	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
+	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list --newline | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
 	TREE_MODE="$bind_tree_mode:change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -t {1})"
 	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d)+change-preview(ls {})"
 	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_index}')+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -w {1})"

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 is_known_tmuxinator_template() {
-	tmuxinator list | grep -q "^$1$"
+	tmuxinator list --newline | grep -q "^$1$"
 }


### PR DESCRIPTION
Given multiple tmuxinator projects, when the list is not long enough, the `tmuxinator list` command lists the projects in columns. This causes the projects to not render as list. 

tmuxinator accepts `--newline` argument to `list` command. See https://github.com/tmuxinator/tmuxinator/blob/master/lib/tmuxinator/cli.rb#L397-L399. This PR uses the `--newline` argument so all tmuxinator projects list properly.

```bash
$ tmuxinator new a
...
$ tmuxinator new b
...
$ tmuxinator list
tmuxinator projects:
a    b
```

In tmuxinator view this list shows up as 
```
> a    b
```

```bash
$ tmuxinator list --newline
tmuxinator projects:
a
b
```
With this PR, in tmuxinator view this would show up as separate projects.
