### PR TITLE
feat: add custom paths subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ set -g @sessionx-x-path '<some-path>'
 # Tip: if you're using zoxide mode, there's a good chance this is redundant
 set -g @sessionx-custom-paths '/Users/me/projects,/Users/me/second-brain'
 
+# A boolean flag, if set to true, will also display subdirectories
+# under the aforementioned custom paths, e.g. /Users/me/projects/tmux-sessionx
+set -g @sessionx-custom-paths-subdirectories 'false'
+
 # By default, the current session will not be shown on first view
 # This is to support quick switch of sessions
 # Only after other actions (e.g. rename) will the current session appear

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -77,12 +77,18 @@ input() {
 additional_input() {
 	sessions=$(tmux list-sessions | sed -E 's/:.*$//')
 	custom_paths=$(tmux_option_or_fallback "@sessionx-custom-paths" "")
+	custom_path_subdirectories=$(tmux_option_or_fallback "@sessionx-custom-paths-subdirectories" "false")
 	if [[ -z "$custom_paths" ]]; then
 		echo ""
 	else
 		clean_paths=$(echo "$custom_paths" | sed -E 's/ *, */,/g' | sed -E 's/^ *//' | sed -E 's/ *$//' | sed -E 's/ /✗/g')
-		for i in ${clean_paths//,/$IFS}; do
-            if grep -q $(basename $i) <<< $sessions; then
+		if [[ "$custom_path_subdirectories" == "true" ]]; then
+			paths=$(find ${clean_paths//,/ } -mindepth 1 -maxdepth 1 -type d)
+		else
+			paths=${clean_paths//,/ }
+		fi
+		for i in ${paths//,/$IFS}; do
+			if grep -q $(basename $i) <<< $sessions; then
 				continue
 			fi
 			echo "$i"


### PR DESCRIPTION
This PR adds an optional flag to also view subdirectories under custom path.
This is done to mimic the behavior in the sessionizer script.
The flag is 
`set -g @sessionx-custom-paths-subdirectories 'false'`
and can be changed to `true` in order to activate this functionality.

No backwards compatibility issues, since if the flag is turned off, the existing behavior remains unchanged.