### PR TITLE
feat(bind): support options in @sessionx-bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ You can change it by adding this line with your desired key:
 # I recommend using `o` if not already in use, for least key strokes when launching
 set -g @sessionx-bind '<mykey>'
 ```
+### Root Binding
+If you want to open sessionx without the prefix (e.g. `Alt-o`),
+you can do so by including `-n` in `@sessionx-bind`:
+```bash
+# M- gets interpreted as "hold Alt" here
+set -g @sessionx-bind '-n M-o'
+```
+
 ### Additional configuration options:
 ```bash
 # `C-x` is a customizeable, by default it indexes directories in `$HOME/.config`,

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -9,4 +9,4 @@ tmux_option_or_fallback() {
 	fi
 	echo "$option_value"
 }
-tmux bind-key "$(tmux_option_or_fallback "@sessionx-bind" "O")" run-shell "$CURRENT_DIR/scripts/sessionx.sh"
+tmux bind-key $(tmux_option_or_fallback "@sessionx-bind" "O") run-shell "$CURRENT_DIR/scripts/sessionx.sh"


### PR DESCRIPTION
I just learned from cmp-git that #7 already exists. I suppose this is an alternative solution for #85.

An example of using this would be

```tmux
set -g @sessionx-bind '-n M-o'
```

I'll add an example to the README, and no hard feelings if you prefer #7 

## security concern?

I call out in the code comment that this is kind of intentionally having users inject code in a string input, but I can't imagine why anyone would put untrusted input here , so... 🤷 ? 