### PR TITLE
change deprecated icon for suported one

### DIFF
--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -54,7 +54,7 @@ tree_mode() {
 		# Display each window
 		tmux lsw -t"$s" -F'#{window_id}' | while read -r w; do
 			W=$(tmux lsw -t"$s" -F'#{window_id}#{T:tree_mode_format}' | grep ^"$w")
-			echo "  ﬌ ${W##$w}"
+			echo "  󰘍 ${W##$w}"
 		done
 	done
 }


### PR DESCRIPTION
# Reason
Described the problem with deprecated NerdFont icon in the referred issue  #128.

# Modifications
Just changed the deprecated `u\{fb0c}` for `u\{f060d}`  at  `/scripts/preview.sh`.
