### PR TITLE
Add option to use `fzf --tmux` instead of the `fzf-tmux` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ set -g @sessionx-custom-paths '/Users/me/projects,/Users/me/second-brain'
 # under the aforementioned custom paths, e.g. /Users/me/projects/tmux-sessionx
 set -g @sessionx-custom-paths-subdirectories 'false'
 
+# Uses `fzf --tmux` instead of the `fzf-tmux` script (requires fzf >= 0.53).
+set -g @sessionx-fzf-builtin-tmux 'on'
+
 # By default, the current session will not be shown on first view
 # This is to support quick switch of sessions
 # Only after other actions (e.g. rename) will the current session appear
@@ -132,7 +135,7 @@ If you want to change the default key bindings, you can do using this configurat
 # This command is equivalent to the 'Enter' key.
 set -g @sessionx-bind-accept 'alt-j'
 
-# Changing this will interactively accept a session 
+# Changing this will interactively accept a session
 # when there's only one match
 # NOTE! auto-accept will many times prevent from
 # creating new sessions.

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -155,6 +155,7 @@ handle_args() {
 	fi
 	Z_MODE=$(tmux_option_or_fallback "@sessionx-zoxide-mode" "off")
 	CONFIGURATION_PATH=$(tmux_option_or_fallback "@sessionx-x-path" "$HOME/.config")
+  FZF_BUILTIN_TMUX=$(tmux_option_or_fallback "@sessionx-fzf-builtin-tmux" "off")
 
 	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list --newline | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
 	TREE_MODE="$bind_tree_mode:change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -t {1})"
@@ -181,6 +182,12 @@ handle_args() {
 
 	HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  $bind_rename_session=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= / $bind_zo="
 
+  if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
+    fzf_size_arg="--tmux"
+  else
+    fzf_size_arg="-p"
+  fi
+
 	args=(
 		--bind "$TMUXINATOR_MODE"
 		--bind "$TREE_MODE"
@@ -206,7 +213,7 @@ handle_args() {
 		--preview-window="${preview_location},${preview_ratio},,"
 		--layout="$layout_mode"
 		--pointer="$pointer_icon"
-		-p "$window_width,$window_height"
+		"${fzf_size_arg}" "$window_width,$window_height"
 		--prompt "$prompt_icon"
 		--print-query
 		--tac
@@ -231,7 +238,12 @@ run_plugin() {
 	window_settings
 	handle_binds
 	handle_args
-	RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
+
+  if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
+    RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf "${fzf_opts[@]}" "${args[@]}" | tail -n1)
+  else
+    RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
+  fi
 }
 
 run_plugin


### PR DESCRIPTION
I've described this solution in #124, so I decided to make a pull request with the solution behind an option, for those who want it. It allows to change between `fzf --tmux` and `fzf-tmux` by setting `set -g @sessionx-fzf-builtin-tmux 'on'`.