### PR TITLE
Add fzf-marks integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ set -g @sessionx-legacy-fzf-support 'on'
 # If found, it'll launch the template using tmuxinator
 set -g @sessionx-tmuxinator-mode 'off'
 
+# Turn on fzf-marks (default: off) mode to launch a new session from your marks
+set -g @sessionx-fzf-marks-mode 'off'
+
 # If you want to filter sessions, use a comma separated list of session names
 # e.g. set -g @sessionx-filtered-sessions 'scratch,somesession'
 # This will filter out sessions that contain 'scratch' (used by tmux-floax)
@@ -133,6 +136,7 @@ If you insert a non-existing name and hit enter, a new session with that name wi
 - `Ctrl-b` "back": reloads the first query. Useful when going into window or expand mode, to go back
 - `Ctrl-t` "tree": reloads the preview with the tree of sessions+windows familiar from the native session manager (C-S)
 - `Ctrl-/` "tmuxinator": fetches a list of tmuxinator sessions and previews them
+- `Ctrl-g` "fzf-marks": show fzf-marks marks
 - `?` toggles the preview pane
 
 ### Rebind keys:
@@ -197,6 +201,9 @@ set -g @sessionx-bind-abort 'alt-q'
 
 # This command opens the tmuxinator list.
 set -g @sessionx-bind-tmuxinator-list 'alt-t'
+
+# This command open fzf-marks marks.
+set -g @sessionx-bind-fzf-marks 'alt-g'
 ```
 
 ## [Tmuxinator](https://github.com/tmuxinator/tmuxinator) Integration 🚀
@@ -211,6 +218,24 @@ set -g @sessionx-tmuxinator-mode 'on'
 
 # Changing the binding from the default Ctrl-/
 set -g @sessionx-bind-tmuxinator-list 'alt-t'
+```
+
+## [fzf-marks](https://github.com/urbainvaes/fzf-marks) Integration 🎯
+
+You can turn on fzf-marks mode with `sessionx-fzf-marks-mode` to quickly jump to your marks in a new session.
+Sessionx will look for marks file in a default location first (`~/.fzf-marks`). **Important**: If the fzf-marks file does not exist,
+fzf-marks mode will not turn on. Currently, you have to manually specify the marks file with `sessionx-fzf-marks-file`
+if you change it to other location (see snippet below).
+
+```bash
+# fzf-marks integration 'on' (default: off)
+set -g @sessionx-fzf-marks-mode 'on'
+
+# Change fzf-marks file to a custom location
+set -g @sessionx-fzf-marks-file '~/.config/fzf-marks'
+
+# Rebind from the default key Ctrl-g
+set -g @sessionx-bind-fzf-marks 'alt-g'
 ```
 
 ## WARNING ⚠️

--- a/scripts/fzf-marks.sh
+++ b/scripts/fzf-marks.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+is_fzf-marks_enabled() {
+  local fzf_marks_mode fzf_marks_file
+  fzf_marks_file=$(get_fzf-marks_file)
+  if [[ -e "${fzf_marks_file}" ]]; then
+	  fzf_marks_mode=$(tmux_option_or_fallback "@sessionx-fzf-marks-mode" "off")
+  fi
+
+  if [[ "$fzf_marks_mode" != "on" ]]; then
+    return 1
+  fi
+
+  return 0
+}
+
+is_fzf-marks_mark(){
+  if $(echo "$@" | grep -q ' : '  2>&1); then
+    return 0
+  fi
+
+  return 1
+}
+
+get_fzf-marks_file() {
+  echo "$(tmux_option_or_fallback "@sessionx-fzf-marks-file" "$HOME/.fzf-marks" | sed "s|~|$HOME|")"
+}
+
+get_fzf-marks_mark() {
+  local mark
+  mark=$(echo "$@" | cut -d: -f1 | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+  echo "$mark"
+}
+
+get_fzf-marks_target() {
+  local target
+  target=$(echo "$@" | cut -d: -f2 | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+  echo "$target"
+}
+
+get_fzf-marks_keybind() {
+  local keybind
+  keybind="$(tmux_option_or_fallback "@sessionx-bind-fzf-marks" "ctrl-g")"
+  echo "$keybind"
+}
+
+load_fzf-marks_binding(){
+  echo "$(get_fzf-marks_keybind):reload(cat $FZF_MARKS_FILE)+change-preview(sed 's/.*: \(.*\)$/\1/' <<< {} | xargs ls)"
+}

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -166,8 +166,7 @@ handle_args() {
 	CONFIGURATION_PATH=$(tmux_option_or_fallback "@sessionx-x-path" "$HOME/.config")
 
 	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list --newline | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
-	FZF_MARKS_FILE=$(tmux_option_or_fallback "@sessionx-fzf-marks-file" "$HOME/.fzf-marks")
-	FZF_MARKS_FILE=$(echo $FZF_MARKS_FILE | sed "s|~|$HOME|")
+	FZF_MARKS_FILE=$(tmux_option_or_fallback "@sessionx-fzf-marks-file" "$HOME/.fzf-marks" | sed "s|~|$HOME|")
 	if [[ -e "$FZF_MARKS_FILE" ]]; then
 		FZF_MARKS_MODE=$(tmux_option_or_fallback "@sessionx-fzf-marks-mode" "off")
 	fi

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -172,7 +172,7 @@ handle_args() {
 		FZF_MARKS_MODE=$(tmux_option_or_fallback "@sessionx-fzf-marks-mode" "off")
 	fi
 	if [[ "$FZF_MARKS_MODE" == "on" ]]; then
-		FZF_MARKS_WINDOW="$bind_fzf_marks:reload(cat $FZF_MARKS_FILE)+change-preview(sed 's/.*: \(.*\)$/\1/' <<< {} | ls)"
+		FZF_MARKS_WINDOW="$bind_fzf_marks:reload(cat $FZF_MARKS_FILE)+change-preview(sed 's/.*: \(.*\)$/\1/' <<< {} | xargs ls)"
 	fi
 	TREE_MODE="$bind_tree_mode:change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -t {1})"
 	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d)+change-preview(ls {})"


### PR DESCRIPTION
Add integration with [fzf-marks](https://github.com/urbainvaes/fzf-marks) with 3 options:
```
@sessionx-fzf-marks-mode 'off'
@sessionx-fzf-marks-file '~/.fzf-marks'
@sessionx-bind-fzf-marks 'ctrl-g'
```

Currently needed to specify the fzf-marks file manually if not in the default location (`~/.fzf-marks`).