### PR TITLE
Make customizable `ls` command for directory preview window

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ set -g @sessionx-prompt " "
 # If you want to change the pointer
 set -g @sessionx-pointer "▶ "
 
+# Customize `ls` command to display your directories nicely (default: `ls`)
+# Can be used with `exa`, `lsd`, or other command of your choice to
+# set preview window to match your preference
+set -g @sessionx-ls-command 'lsd --tree --color=always --icon=always'
+
 # When set to 'on' a non-result will be sent to zoxide for path matching
 # Requires zoxide installed
 set -g @sessionx-zoxide-mode 'on'

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -159,10 +159,10 @@ handle_args() {
 
 	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list --newline | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
 	TREE_MODE="$bind_tree_mode:change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -t {1})"
-	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d)+change-preview($LS_COMMAND {})"
+	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -xtype d)+change-preview($LS_COMMAND {})"
 	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -w {1})"
 
-	NEW_WINDOW="$bind_new_window:reload(find $PWD -mindepth 1 -maxdepth 1 -type d)+change-preview($LS_COMMAND {})"
+	NEW_WINDOW="$bind_new_window:reload(find $PWD -mindepth 1 -maxdepth 1 -xtype d)+change-preview($LS_COMMAND {})"
 	ZO_WINDOW="$bind_zo:reload(zoxide query -l)+change-preview($LS_COMMAND {})"
 	BACK="$bind_back:reload(echo -e \"${INPUT// /}\")+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh {1})"
 	KILL_SESSION="$bind_kill_session:execute-silent(tmux kill-session -t {})+reload(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/reload_sessions.sh)"

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -145,6 +145,7 @@ handle_output() {
 }
 
 handle_args() {
+	LS_COMMAND=$(tmux_option_or_fallback "@sessionx-ls-command" "ls")
 	INPUT=$(input)
 	ADDITIONAL_INPUT=$(additional_input)
 	if [[ -n $ADDITIONAL_INPUT ]]; then
@@ -158,11 +159,11 @@ handle_args() {
 
 	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list --newline | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
 	TREE_MODE="$bind_tree_mode:change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -t {1})"
-	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d)+change-preview(ls {})"
+	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d)+change-preview($LS_COMMAND {})"
 	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -w {1})"
 
-	NEW_WINDOW="$bind_new_window:reload(find $PWD -mindepth 1 -maxdepth 1 -type d)+change-preview(ls {})"
-	ZO_WINDOW="$bind_zo:reload(zoxide query -l)+change-preview(ls {})"
+	NEW_WINDOW="$bind_new_window:reload(find $PWD -mindepth 1 -maxdepth 1 -type d)+change-preview($LS_COMMAND {})"
+	ZO_WINDOW="$bind_zo:reload(zoxide query -l)+change-preview($LS_COMMAND {})"
 	BACK="$bind_back:reload(echo -e \"${INPUT// /}\")+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh {1})"
 	KILL_SESSION="$bind_kill_session:execute-silent(tmux kill-session -t {})+reload(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/reload_sessions.sh)"
 


### PR DESCRIPTION
A custom command can be specified with `@sessionx-ls-command`

Example usage with [lsd](https://github.com/lsd-rs/lsd):
```
set -g @sessionx-ls-command 'lsd --tree --color=always --almost-all --group-dirs=first --depth=2'
```

Preview:
![image](https://github.com/user-attachments/assets/a1287db1-d1df-4b57-82e2-b19514172128)


Affected mode:

- Zoxide mode
- Config/configurable mode
- New window/Expand mode
- Possibly fzf-marks mode from #141 if pulled