### PR TITLE
fix(tmuxinator): dynamic binding and mode checks

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURRENT="$(tmux display-message -p '#S')"
 Z_MODE="off"
 
-source scripts/tmuxinator.sh
+source "$CURRENT_DIR/tmuxinator.sh"
 
 get_sorted_sessions() {
 	last_session=$(tmux display-message -p '#{client_last_session}')
@@ -43,7 +44,6 @@ window_settings() {
 }
 
 handle_binds() {
-	bind_tmuxinator_list=$(tmux_option_or_fallback "@sessionx-bind-tmuxinator-list" "ctrl-/")
 	bind_tree_mode=$(tmux_option_or_fallback "@sessionx-bind-tree-mode" "ctrl-t")
 	bind_window_mode=$(tmux_option_or_fallback "@sessionx-bind-window-mode" "ctrl-w")
 	bind_configuration_mode=$(tmux_option_or_fallback "@sessionx-bind-configuration-path" "ctrl-x")
@@ -126,7 +126,7 @@ handle_output() {
 	fi
 
 	if ! tmux has-session -t="$target" 2>/dev/null; then
-		if is_known_tmuxinator_template "$target"; then
+		if is_tmuxinator_enabled && is_tmuxinator_template "$target"; then
 			tmuxinator start "$target"
 		elif test -d "$target"; then
 			d_target="$(basename "$target" | tr -d '.')"
@@ -221,6 +221,10 @@ handle_args() {
 	auto_accept=$(tmux_option_or_fallback "@sessionx-auto-accept" "off")
 	if [[ "${auto_accept}" == "on" ]]; then
 		args+=(--bind one:accept)
+	fi
+
+	if $(is_tmuxinator_enabled); then
+		args+=(--bind "$(load_tmuxinator_binding)")
 	fi
 
 	eval "fzf_opts=($additional_fzf_options)"

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -156,7 +156,6 @@ handle_args() {
 	Z_MODE=$(tmux_option_or_fallback "@sessionx-zoxide-mode" "off")
 	CONFIGURATION_PATH=$(tmux_option_or_fallback "@sessionx-x-path" "$HOME/.config")
 
-	TMUXINATOR_MODE="$bind_tmuxinator_list:reload(tmuxinator list --newline | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
 	TREE_MODE="$bind_tree_mode:change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -t {1})"
 	CONFIGURATION_MODE="$bind_configuration_mode:reload(find $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d)+change-preview(ls {})"
 	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -w {1})"
@@ -182,7 +181,6 @@ handle_args() {
 	HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  $bind_rename_session=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= / $bind_zo="
 
 	args=(
-		--bind "$TMUXINATOR_MODE"
 		--bind "$TREE_MODE"
 		--bind "$CONFIGURATION_MODE"
 		--bind "$WINDOWS_MODE"

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
-is_known_tmuxinator_template() {
+is_tmuxinator_enabled() {
+	local tmuxinator_mode=$(tmux_option_or_fallback "@sessionx-tmuxinator-mode" "off")
+
+	if [[ "$tmuxinator_mode" != "on" ]]; then
+		return 1
+	fi
+
+	return 0
+}
+
+is_tmuxinator_template() {
 	tmuxinator list --newline | grep -q "^$1$"
+}
+
+load_tmuxinator_binding() {
+	local keybind="$(tmux_option_or_fallback "@sessionx-bind-tmuxinator-list" "ctrl-/")"
+
+	printf "$keybind:reload(tmuxinator list --newline | sed '1d')+change-preview(cat ~/.config/tmuxinator/{}.yml 2>/dev/null)"
 }


### PR DESCRIPTION
- Add `is_tmuxinator_enabled` function to check if tmuxinator mode is active.
- Dynamically load tmuxinator key binding using `load_tmuxinator_binding`.
- Refactor source path in `sessionx.sh` to use the correct path.