### PR TITLE
fzf-marks should use @sessionx-fzf-marks-file and @sessionx-ls-command

### DIFF
--- a/scripts/fzf-marks.sh
+++ b/scripts/fzf-marks.sh
@@ -45,5 +45,5 @@ get_fzf-marks_keybind() {
 }
 
 load_fzf-marks_binding(){
-  echo "$(get_fzf-marks_keybind):reload(cat $FZF_MARKS_FILE)+change-preview(sed 's/.*: \(.*\)$/\1/' <<< {} | xargs ls)"
+  echo "$(get_fzf-marks_keybind):reload(cat $(get_fzf-marks_file))+change-preview(sed 's/.*: \(.*\)$/\1/' <<< {} | xargs $(tmux_option_or_fallback "@sessionx-ls-command" "ls"))"
 }


### PR DESCRIPTION
The new script `fzf-marks.sh` is not using the tmux variable `@sessionx-fzf-marks-file` consistently. In `load_fzf-marks_binding()` the environment variable `$FZF_MARKS_FILE` is used instead.

Additionally, the new variable `@sessionx-ls-command` should be used as preview command (with `ls` as fallback).