### PR TITLE
fix(tmuxinator): return value

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -155,6 +155,8 @@ handle_output() {
 		fi
 	fi
 	tmux switch-client -t "$target"
+
+	exit 0
 }
 
 handle_args() {


### PR DESCRIPTION
Seems like bash functions inherit the exit status of previously called function. Adds an explicit exit statement to always return success at function end.

closes #147