### PR TITLE
fix(zoxide): order by frecency asc

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ If you insert a non-existing name and hit enter, a new session with that name wi
 - `Ctrl-p` select preview down
 - `Ctrl-r` "read": will launch a `read` prompt to rename a session within the list
 - `Ctrl-w` "window": will reload the list with all the available _windows_ and their preview
+- `Ctrl-f` will search zoxide paths ordered by [frecency](https://github.com/ajeetdsouza/zoxide/wiki/Algorithm#frecency)
 - `Ctrl-x` will fuzzy read `~/.config` or a configurable path of your choice (with `@session-x-path`)
 - `Ctrl-e` "expand": will expand `PWD` and search for local directories to create additional session from
 - `Ctrl-b` "back": reloads the first query. Useful when going into window or expand mode, to go back

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -178,7 +178,7 @@ handle_args() {
 	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh -w {1})"
 
 	NEW_WINDOW="$bind_new_window:reload(find $PWD -mindepth 1 -maxdepth 1 -type d -o -type l)+change-preview($LS_COMMAND {})"
-	ZO_WINDOW="$bind_zo:reload(zoxide query -l)+change-preview($LS_COMMAND {})"
+	ZO_WINDOW="$bind_zo:reload(zoxide query -l | tac)+change-preview($LS_COMMAND {})"
 	BACK="$bind_back:reload(echo -e \"${INPUT// /}\")+change-preview(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/preview.sh {1})"
 	KILL_SESSION="$bind_kill_session:execute-silent(tmux kill-session -t {})+reload(${TMUX_PLUGIN_MANAGER_PATH%/}/tmux-sessionx/scripts/reload_sessions.sh)"
 


### PR DESCRIPTION
This MR will put the most "frecent" path on the bottom of fzf's list, near the input field, auto-selecting the most frecent.

![image](https://github.com/user-attachments/assets/881fcf0f-0726-4f72-872b-68ca900047cc)

Also, I updated the README because there was no mention of `Ctrl+f` for searching zoxide's list.