### PR TITLE
Feature: support path expansion with custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ set -g @sessionx-prefix off
 # e.g. set -g @sessionx-x-path '~/dotfiles'
 set -g @sessionx-x-path '<some-path>'
 
-# A comma delimited absolute-paths list of custom paths
-# always visible in results and ready to create a session from.
+# A comma delimited list of custom paths to always be visible in results
+# and ready to create a session from. Supports glob expansions.
 # Tip: if you're using zoxide mode, there's a good chance this is redundant
-set -g @sessionx-custom-paths '/Users/me/projects,/Users/me/second-brain'
+set -g @sessionx-custom-paths "$HOME/projects,$HOME/nested-projects/*/modules/*"
 
 # A boolean flag, if set to true, will also display subdirectories
 # under the aforementioned custom paths, e.g. /Users/me/projects/tmux-sessionx

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -52,7 +52,7 @@ additional_input() {
 		if [[ "$custom_path_subdirectories" == "true" ]]; then
 			paths=$(find ${clean_paths//,/ } -mindepth 1 -maxdepth 1 -type d)
 		else
-			paths=${clean_paths//,/ }
+			paths=$(find ${clean_paths//,/ } -mindepth 0 -maxdepth 0 -type d)
 		fi
 		add_path() {
 			local path=$1


### PR DESCRIPTION
I was an [early adopter](https://github.com/omerxx/tmux-sessionx/tree/847cf28c836da1219e039cb7c4379a2c314a8a04) of this plugin and recently updated it and it broke my use of custom paths which allowed glob style expansions.

Many of my projects have seperate modules under a top level project name, using something like 
```
set -g @sessionx-custom-paths "$HOME/nested-projects/*/modules/*"
```
used to work well.

`@sessionx-custom-paths-subdirectories` kind of did what I wanted, but having complete control over subdirectories is even better.

* Used the same functionality as subdirectories, but only list direct matches
* Updated the README example to include double quotes to show that it is possible for environment variable expansions in tmux.conf