### PR TITLE
Fix: Consistent fzf-tmux Handling and Option Passing

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -129,37 +129,18 @@ run_plugin() {
 	handle_input
 	args+=(--bind "$BACK")
 
-	if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
-		# Extract dimensions from args
-		dimensions=""
-		# Need to filter out -p flag and dimensions from args
-		declare -a filtered_args=()
-		for ((i=0; i<${#args[@]}; i++)); do
-			arg="${args[i]}"
-			# Skip -p flag but capture dimensions
-			if [[ "$arg" == "-p" && $((i+1)) -lt ${#args[@]} ]]; then
-				dimensions="${args[i+1]}"
-				# Skip both flag and dimensions
-				((i++))
-				continue
-			fi
-			# Also capture dimensions directly if they match the pattern
-			if [[ "$arg" =~ [0-9]+%,[0-9]+% ]]; then
-				dimensions="$arg"
-				continue
-			fi
-			filtered_args+=("$arg")
-		done
-		
-		# If dimensions weren't found, use default
-		if [[ -z "$dimensions" ]]; then
-			dimensions="75%,75%"
-		fi
-		
-		# Use separate --tmux flag with extracted dimensions for FZF
-		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf --tmux="$dimensions" "${fzf_opts[@]}" "${filtered_args[@]}" | tail -n1)
+	# Use the fzf-builtin-tmux option from extra_options
+	fzf_builtin_tmux=${extra_options["fzf-builtin-tmux"]}
+	window_width=${extra_options["window-width"]}
+	window_height=${extra_options["window-height"]}
+	dimensions="${window_width},${window_height}"
+
+	if [[ "$fzf_builtin_tmux" == "on" ]]; then
+		# Use fzf with --tmux flag
+		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf --tmux="$dimensions" "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	else
-		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
+		# Use fzf-tmux with -p flag
+		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux -p "$dimensions" "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	fi
 }
 

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -130,7 +130,7 @@ run_plugin() {
 	args+=(--bind "$BACK")
 
 	if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
-		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf "${fzf_opts[@]}" "${args[@]}" | tail -n1)
+		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf --tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	else
 		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	fi

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -96,12 +96,6 @@ handle_args() {
 		HEADER="$HEADER  $(get_fzf-marks_keybind)=󰣉"
 	fi
 
-	if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
-		fzf_size_arg="--tmux"
-	else
-		fzf_size_arg="-p"
-	fi
-
 	args=(
 		--bind "$TREE_MODE"
 		--bind "$CONFIGURATION_MODE"
@@ -125,7 +119,6 @@ handle_args() {
 		--preview-window="${preview_location},${preview_ratio},,"
 		--layout="$layout_mode"
 		--pointer="$pointer_icon"
-		"${fzf_size_arg}" "$window_width,$window_height"
 		--prompt "$prompt_icon"
 		--print-query
 		--tac
@@ -160,6 +153,9 @@ handle_extra_options() {
 	extra_options["filter-current"]=$(tmux_option_or_fallback "@sessionx-filter-current" "true")
 	extra_options["custom-paths"]=$(tmux_option_or_fallback "@sessionx-custom-paths" "")
 	extra_options["custom-paths-subdirectories"]=$(tmux_option_or_fallback "@sessionx-custom-paths-subdirectories" "false")
+	extra_options["fzf-builtin-tmux"]=$FZF_BUILTIN_TMUX
+	extra_options["window-width"]=$window_width
+	extra_options["window-height"]=$window_height
 	tmux set-option -g @sessionx-_built-extra-options "$(declare -p extra_options)"
 }
 


### PR DESCRIPTION
# Fix: Consistent fzf-tmux Handling and Option Passing

## Problem

At present the plugin doesn't work properly with fzf installations that lack the fzf-tmux binary, and the fzf --tmux support is not working.

## Replicating the problem

### Environment

- system-details :

```bash
zyon@zyon-ubuntu
----------------
OS: Ubuntu 24.04.2 LTS x86_64
Kernel: 6.11.0-21-generic
Uptime: 3 hours, 14 mins
Packages: 2702 (dpkg), 7 (flatpak), 13 (snap)
Shell: zsh 5.9
Resolution: 2880x1620, 3840x2160
WM: i3
Theme: catppuccin-mocha-blue-standard+default [GTK2/3]
Icons: Papirus-Dark [GTK2/3]
Terminal: tmux
CPU: 11th Gen Intel i5-11600K (12) @ 4.900GHz
GPU: NVIDIA GeForce RTX 3060 Ti Lite Hash Rate
GPU: Intel RocketLake-S GT1 [UHD Graphics 750]
Memory: 7580MiB / 31853MiB
```

- fzf = 0.60.0 (built from source with default options)
- fzf-tmux = None (as fzf supports --tmux)
- zoxide = 0.9.7
- tmux = 3.4
- bat = 0.25.0

#### .config/tmux/tmux.conf

```bash
set-window-option -g mode-keys vi

# List of plugins
set -g @plugin 'tmux-plugins/tpm'
set -g @plugin 'tmux-plugins/tmux-sensible'

#set -g @plugin '/home/zyon/workspace/dev/tmux-sessionx'
set -g @plugin 'omerxx/tmux-sessionx'
set -g @plugin 'omerxx/tmux-floax'

set -g @sessionx-bind 'o'
set -g @sessionx-fzf-builtin-tmux 'on'

# Other examples:
# set -g @plugin 'github_username/plugin_name'
# set -g @plugin 'github_username/plugin_name#branch'
# set -g @plugin 'git@github.com:user/plugin'
# set -g @plugin 'git@bitbucket.com:user/plugin'

# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
run '~/.config/tmux/plugins/tpm/tpm'
```

### Expected Behavior

When the user presses the hotkey in a tmux session - in my case `<tmux-prefix>+o` a tmux-sessionx window should open

### Actual Behavior

Nothing happens, no tmux-sessionx window spawns and no errors get logged in tmux log file either.

### How error was traced

#### modified `run_plugin()` in`sessionx.sh` to print out the args

```bash
run_plugin() {
	LOG_FILE="${CURRENT_DIR}/sessionx_debug.log"
	echo "$(date '+%Y-%m-%d %H:%M:%S') ======= run_plugin started =======" >> "$LOG_FILE"
	
	echo "$(date '+%Y-%m-%d %H:%M:%S') Current session: $CURRENT" >> "$LOG_FILE"
	echo "$(date '+%Y-%m-%d %H:%M:%S') Z_MODE: $Z_MODE" >> "$LOG_FILE"
	
	echo "$(date '+%Y-%m-%d %H:%M:%S') Evaluating tmux options..." >> "$LOG_FILE"
	eval $(tmux show-option -gqv @sessionx-_built-args)
	echo "$(date '+%Y-%m-%d %H:%M:%S') Built args evaluated" >> "$LOG_FILE"
	
	eval $(tmux show-option -gqv @sessionx-_built-extra-options)
	echo "$(date '+%Y-%m-%d %H:%M:%S') Built extra options evaluated" >> "$LOG_FILE"
	
	echo "$(date '+%Y-%m-%d %H:%M:%S') Calling handle_input..." >> "$LOG_FILE"
	handle_input
	echo "$(date '+%Y-%m-%d %H:%M:%S') handle_input completed" >> "$LOG_FILE"
	echo "$(date '+%Y-%m-%d %H:%M:%S') BACK value: $BACK" >> "$LOG_FILE"
	
	args+=(--bind "$BACK")
	echo "$(date '+%Y-%m-%d %H:%M:%S') args after adding BACK: ${args[*]}" >> "$LOG_FILE"
	echo "$(date '+%Y-%m-%d %H:%M:%S') fzf_opts: ${fzf_opts[*]}" >> "$LOG_FILE"
	echo "$(date '+%Y-%m-%d %H:%M:%S') INPUT value: $INPUT" >> "$LOG_FILE"
	echo "$(date '+%Y-%m-%d %H:%M:%S') FZF_BUILTIN_TMUX: $FZF_BUILTIN_TMUX" >> "$LOG_FILE"

	if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
		echo "$(date '+%Y-%m-%d %H:%M:%S') Using built-in fzf..." >> "$LOG_FILE"
		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf "${fzf_opts[@]}" "${args[@]}" | tail -n1)
		echo "$(date '+%Y-%m-%d %H:%M:%S') fzf completed with exit code: $?" >> "$LOG_FILE"
	else
		echo "$(date '+%Y-%m-%d %H:%M:%S') Using fzf-tmux..." >> "$LOG_FILE"
		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
		echo "$(date '+%Y-%m-%d %H:%M:%S') fzf-tmux completed with exit code: $?" >> "$LOG_FILE"
	fi
	
	echo "$(date '+%Y-%m-%d %H:%M:%S') RESULT: $RESULT" >> "$LOG_FILE"
	echo "$(date '+%Y-%m-%d %H:%M:%S') ======= run_plugin ended =======" >> "$LOG_FILE"
}
```

#### Log Output
Invoking the sessionx plugin via the hotkey defined in configuration file generated this output in the logfile -
```bash
2025-03-29 16:28:31 ======= run_plugin started =======
2025-03-29 16:28:31 Current session: default
2025-03-29 16:28:31 Z_MODE: off
2025-03-29 16:28:31 Evaluating tmux options...
2025-03-29 16:28:31 Built args evaluated
2025-03-29 16:28:31 Built extra options evaluated
2025-03-29 16:28:31 Calling handle_input...
2025-03-29 16:28:31 handle_input completed
2025-03-29 16:28:31 BACK value: ctrl-b:reload(echo -e "")+change-preview(/home/zyon/.config/tmux/plugins/tmux-sessionx/scripts/preview.sh {1})
2025-03-29 16:28:31 args after adding BACK: --bind ctrl-t:change-preview(/home/zyon/.config/tmux/plugins/tmux-sessionx/scripts/preview.sh -t {1}) --bind ctrl-x:reload(find /home/zyon/.config -mindepth 1 -maxdepth 1 -type d -o -type l)+change-preview(ls {}) --bind ctrl-w:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(/home/zyon/.config/tmux/plugins/tmux-sessionx/scripts/preview.sh -w {1}) --bind ctrl-e:reload(find /home/zyon -mindepth 1 -maxdepth 1 -type d -o -type l)+change-preview(ls {}) --bind ctrl-f:reload(zoxide query -l)+change-preview(ls {}) --bind alt-bspace:execute-silent(tmux kill-session -t {})+reload(/home/zyon/.config/tmux/plugins/tmux-sessionx/scripts/reload_sessions.sh) --bind bspace:backward-delete-char --bind esc:abort --bind ctrl-n:up --bind ctrl-p:down --bind enter:replace-query+print-query --bind ctrl-u:preview-half-page-up --bind ctrl-d:preview-half-page-down --bind ctrl-r:execute(bash -c ' printf >&2 "New name: ";read name; tmux rename-session -t {1} "\"; ')+reload(bash -c ' tmux list-sessions | sed -E "s/:.*$//"; ') --bind ?:toggle-preview --bind change:first --exit-0 --header=enter=󰿄  alt-bspace=󱂧  ctrl-r=󰑕  ctrl-x=󱃖  ctrl-w=  ctrl-e=󰇘  ctrl-b=󰌍  ctrl-t=󰐆  ctrl-u=  ctrl-d= / ctrl-f= --preview=/home/zyon/.config/tmux/plugins/tmux-sessionx/scripts/preview.sh {} --preview-window=top,75%,, --layout=default --pointer=▶ --tmux 75%,75% --prompt   --print-query --tac --scrollbar ▌▐ --border-label Current session: ""  --bind focus:transform-preview-label:echo [ {} ] --bind ctrl-b:reload(echo -e "")+change-preview(/home/zyon/.config/tmux/plugins/tmux-sessionx/scripts/preview.sh {1})
2025-03-29 16:28:31 fzf_opts: 
2025-03-29 16:28:31 INPUT value: 
2025-03-29 16:28:31 FZF_BUILTIN_TMUX: 
2025-03-29 16:28:31 Using fzf-tmux...
2025-03-29 16:28:31 fzf-tmux completed with exit code: 0
2025-03-29 16:28:31 RESULT: 
2025-03-29 16:28:31 ======= run_plugin ended =======
```

### Conclusion

As can be seen from above log, for some reason args set in the `sessionx.tmux` are not passed to the `sessionx.sh` script. This is a bug, and since my gripe was with how the fzf call was being handled, I have opened this PR to fix the issue. There may still be some issues with other args, not that I ran into them given this is my first time even using this plugin.

### This PR fixes the usage of args in the fzf calls.

#### Major Change:
Refactors the handling of `fzf-tmux` vs. `fzf --tmux` calls. Instead of setting size parameters in `sessionx.tmux`, the size parameters and the `fzf-builtin-tmux` setting are now passed through to `sessionx.sh` via  `extra_options` array. The `sessionx.sh` script then uses these options to correctly execute either `fzf` with the `--tmux` parameter or `fzf-tmux` with the `-p` 

#### Fixes:
Resolves inconsistencies in how the user can configure sessionx to plain `fzf` in tmux rather than `fzf-tmux`. This provides more flexibility better handles scenarios where older versions of fzf are present.