### PR TITLE
chore(nix): Fixes the warning log

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,7 @@
         packages.default = pkgs.tmuxPlugins.mkTmuxPlugin {
           pluginName = "sessionx";
           version = "dev";
-
-          src = ./.;
+          src = builtins.path { path = ./.; name = "source"; };
           nativeBuildInputs = [pkgs.makeWrapper];
 
           postPatch = ''


### PR DESCRIPTION
This commit fixes the log warning that nix gives.

```log
warning: Performing inefficient double copy of path
'«github:omerxx/tmux-sessionx/42c18389e73b80381d054dd1005b8c9a66942248?narHash=sha256-SRKI4mliMSMp/Yd%2BoSn48ArbbRA%2Bszaj70BQeTd8NhM%3D»/nix/store/kd1z9c9x1h3yi8r12qj2a5jq45yalwfi-source'
to the store. This can typically be avoided by rewriting an attribute
like `src = ./.` to `src = builtins.path { path = ./.; name = "source";
}`.
```