### PR TITLE
feat: add interactive help system with Ctrl-h keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ If you insert a non-existing name and hit enter, a new session with that name wi
 - `Ctrl-t` "tree": reloads the preview with the tree of sessions+windows familiar from the native session manager (C-S)
 - `Ctrl-/` "tmuxinator": fetches a list of tmuxinator sessions and previews them
 - `Ctrl-g` "fzf-marks": show fzf-marks marks
+- `Ctrl-h` "help": displays a help screen with all keybindings
 - `?` toggles the preview pane
 
 ### Rebind keys:
@@ -250,6 +251,10 @@ set -g @sessionx-bind-tmuxinator-list 'alt-t'
 
 # This command open fzf-marks marks.
 set -g @sessionx-bind-fzf-marks 'alt-g'
+
+# This command opens the help screen.
+# By default, it is set to `ctrl-h`.
+set -g @sessionx-bind-help 'alt-h'
 ```
 
 ## [Tmuxinator](https://github.com/tmuxinator/tmuxinator) Integration 🚀

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Generate help text for sessionx keybindings
+cat << 'EOF'
+╭─────────────────────────────────────────────────────────────────────────╮
+│                        SessionX Keybindings Help                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Navigation                                                              │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ ↑/↓ or C-n/C-p   Navigate list                                         │
+│ Enter            Open selected session/window                           │
+│ Esc              Exit SessionX                                          │
+│                                                                         │
+│ Session Management                                                      │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ Alt+Backspace    Kill selected session                                  │
+│ Ctrl-r           Rename selected session                                │
+│                                                                         │
+│ View Modes                                                              │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ Ctrl-w           Switch to window mode (list all windows)              │
+│ Ctrl-t           Switch to tree mode (hierarchical view)               │
+│ Ctrl-/           Show tmuxinator templates                              │
+│ Ctrl-g           Show fzf-marks marks                                   │
+│ Ctrl-e           Expand current directory for new sessions              │
+│ Ctrl-x           Browse configuration directory                        │
+│ Ctrl-b           Go back to session list                               │
+│                                                                         │
+│ Preview Controls                                                        │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ ?                Toggle preview pane on/off                             │
+│ Ctrl-u           Scroll preview up                                      │
+│ Ctrl-d           Scroll preview down                                    │
+│                                                                         │
+│ Tips                                                                    │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ • Type a new name and press Enter to create a new session              │
+│ • With zoxide enabled, non-existing paths will be searched             │
+│ • Custom paths from config are shown with ✗ replacing spaces           │
+│ • Sessions are sorted by most recently used                             │
+│                                                                         │
+│ Press any key to return...                                              │
+╰─────────────────────────────────────────────────────────────────────────╯
+EOF

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -59,6 +59,7 @@ handle_binds() {
 	bind_select_up=$(tmux_option_or_fallback "@sessionx-bind-select-up" "ctrl-n")
 	bind_select_down=$(tmux_option_or_fallback "@sessionx-bind-select-down" "ctrl-p")
 
+	bind_help=$(tmux_option_or_fallback "@sessionx-bind-help" "ctrl-h")
 }
 
 handle_args() {
@@ -90,6 +91,7 @@ handle_args() {
 	RENAME_SESSION_EXEC='bash -c '\'' printf >&2 "New name: ";read name; tmux rename-session -t {1} "${name}"; '\'''
 	RENAME_SESSION_RELOAD='bash -c '\'' tmux list-sessions | sed -E "s/:.*$//"; '\'''
 	RENAME_SESSION="$bind_rename_session:execute($RENAME_SESSION_EXEC)+reload($RENAME_SESSION_RELOAD)"
+	HELP="$bind_help:execute-silent(${SCRIPTS_DIR%/}/help.sh  < /dev/null |  less -R)"
 
 	HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  $bind_rename_session=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= / $bind_zo="
 	if is_fzf-marks_enabled; then
@@ -117,6 +119,7 @@ handle_args() {
 		--bind "$SCROLL_UP"
 		--bind "$SCROLL_DOWN"
 		--bind "$RENAME_SESSION"
+		--bind "$HELP"
 		--bind '?:toggle-preview'
 		--bind 'change:first'
 		--exit-0


### PR DESCRIPTION
- Add help.sh script showing all keybindings in a formatted display
- Add Ctrl-h binding (configurable via @sessionx-bind-help)
- Update header to show help is available
- Document in README with keybind customization example

This improves discoverability of features by allowing users to see all available keybindings without leaving the sessionx interface.