### PR TITLE
fix: Replace replace with replace-fail

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,11 @@
 
           postPatch = ''
             substituteInPlace sessionx.tmux \
-              --replace "\$CURRENT_DIR/scripts/sessionx.sh" "$out/share/tmux-plugins/sessionx/scripts/sessionx.sh"
+              --replace-fail "\$CURRENT_DIR/scripts/sessionx.sh" "$out/share/tmux-plugins/sessionx/scripts/sessionx.sh"
             substituteInPlace scripts/sessionx.sh \
-              --replace "/tmux-sessionx/scripts/preview.sh" "$out/share/tmux-plugins/sessionx/scripts/preview.sh"
+              --replace-fail "/tmux-sessionx/scripts/preview.sh" "$out/share/tmux-plugins/sessionx/scripts/preview.sh"
             substituteInPlace scripts/sessionx.sh \
-              --replace "/tmux-sessionx/scripts/reload_sessions.sh" "$out/share/tmux-plugins/sessionx/scripts/reload_sessions.sh"
+              --replace-fail "/tmux-sessionx/scripts/reload_sessions.sh" "$out/share/tmux-plugins/sessionx/scripts/reload_sessions.sh"
           '';
 
           postInstall = ''


### PR DESCRIPTION
As per the [advice I received in my PR in Nixpkgs](https://github.com/NixOS/nixpkgs/pull/415643#discussion_r2153521193), I replaced `replace` with `replace-fail`. This is best practice.