### PR TITLE
Fix the @sessionx-zoxide-mode config

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -124,6 +124,7 @@ handle_input() {
 }
 
 run_plugin() {
+	Z_MODE=$(tmux_option_or_fallback "@sessionx-zoxide-mode" "off")
 	eval $(tmux show-option -gqv @sessionx-_built-args)
 	eval $(tmux show-option -gqv @sessionx-_built-extra-options)
 	handle_input

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -66,7 +66,6 @@ handle_args() {
 	if [[ "$preview_enabled" == "true" ]]; then
 		PREVIEW_LINE="${SCRIPTS_DIR%/}/preview.sh ${PREVIEW_OPTIONS} {}"
 	fi
-	Z_MODE=$(tmux_option_or_fallback "@sessionx-zoxide-mode" "off")
 	CONFIGURATION_PATH=$(tmux_option_or_fallback "@sessionx-x-path" "$HOME/.config")
 	FZF_BUILTIN_TMUX=$(tmux_option_or_fallback "@sessionx-fzf-builtin-tmux" "off")
 


### PR DESCRIPTION
The `Z_MODE` variable was not affected by the configuration. If the `tmux_option_or_fallback` call is moved in the `run_plugin` function of the `sessionx.sh` script, the variable is correctly updated.