### PR TITLE
feat: Add startup command for new sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ set -g @sessionx-additional-options "--color pointer:9,spinner:92,marker:46"
 # Upgrade, or use this setting for support
 set -g @sessionx-legacy-fzf-support 'on'
 
+# Define a command to be executed automatically when a new session is created.
+# Use {session} as a placeholder for the new session's name and {path} for its working directory.
+# Example: set -g @sessionx-startup-command 'tmux new-window -t {session}:1 -n editor "nvim {path}" && tmux new-window -t {session}:2 -n shell'
+set -g @sessionx-startup-command '<command>'
+
 # With Tmuxinator turned 'on' (off by default), the plugin will take a given name
 # and look for a tmuxinator project with that name.
 # If found, it'll launch the template using tmuxinator


### PR DESCRIPTION
Introduces a new configuration option `@sessionx-startup-command` that allows users to define a command to be executed automatically when a new tmux session is created via sessionx.

The command supports placeholders `{session}` for the new session's name and `{path}` for its working directory, enabling flexible initial setup for new environments.