### PR TITLE
fix: use standard maps for select-up and select-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ If you insert a non-existing name and hit enter, a new session with that name wi
 - `alt+backspace` will delete the selected session
 - `Ctrl-u` scroll preview up
 - `Ctrl-d` scroll preview down
-- `Ctrl-n` select preview up
-- `Ctrl-p` select preview down
+- `Ctrl-p` select session up
+- `Ctrl-n` select session down
 - `Ctrl-r` "read": will launch a `read` prompt to rename a session within the list
 - `Ctrl-w` "window": will reload the list with all the available _windows_ and their preview
 - `Ctrl-x` will fuzzy read `~/.config` or a configurable path of your choice (with `@session-x-path`)

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -56,8 +56,8 @@ handle_binds() {
 	bind_scroll_up=$(tmux_option_or_fallback "@sessionx-bind-scroll-up" "ctrl-u")
 	bind_scroll_down=$(tmux_option_or_fallback "@sessionx-bind-scroll-down" "ctrl-d")
 
-	bind_select_up=$(tmux_option_or_fallback "@sessionx-bind-select-up" "ctrl-n")
-	bind_select_down=$(tmux_option_or_fallback "@sessionx-bind-select-down" "ctrl-p")
+	bind_select_up=$(tmux_option_or_fallback "@sessionx-bind-select-up" "ctrl-p")
+	bind_select_down=$(tmux_option_or_fallback "@sessionx-bind-select-down" "ctrl-n")
 
 }
 


### PR DESCRIPTION
Sets the expected default directions for ctrl+p / ctrl+n when selecting sessions.

This fixes #107. There was a linked PR in that issue but the author closed it without explanation.