### PR TITLE
feat: Add custom paths subdirectory max depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ set -g @sessionx-custom-paths '/Users/me/projects,/Users/me/second-brain'
 # under the aforementioned custom paths, e.g. /Users/me/projects/tmux-sessionx
 set -g @sessionx-custom-paths-subdirectories 'false'
 
+## An integer value, if `@sessionx-custom-paths-subdirectories` is set to true,
+## this value will determine how deep the search for subdirectories will go.
+set -g @sessionx-custom-paths-max-depth '1'
+
 # Uses `fzf --tmux` instead of the `fzf-tmux` script (requires fzf >= 0.53).
 set -g @sessionx-fzf-builtin-tmux 'on'
 

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -45,12 +45,13 @@ additional_input() {
 	sessions=$(get_sorted_sessions)
 	custom_paths=${extra_options["custom-paths"]}
 	custom_path_subdirectories=${extra_options["custom-paths-subdirectories"]}
+	custom_path_max_depth=${extra_options["custom-paths-max-depth"]}
 	if [[ -z "$custom_paths" ]]; then
 		echo ""
 	else
 		clean_paths=$(echo "$custom_paths" | sed -E 's/ *, */,/g' | sed -E 's/^ *//' | sed -E 's/ *$//' | sed -E 's/ /✗/g')
 		if [[ "$custom_path_subdirectories" == "true" ]]; then
-			paths=$(find ${clean_paths//,/ } -mindepth 1 -maxdepth 1 -type d)
+			paths=$(find ${clean_paths//,/ } -mindepth 1 -maxdepth "$custom_path_max_depth" -type d)
 		else
 			paths=${clean_paths//,/ }
 		fi

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -159,6 +159,7 @@ handle_extra_options() {
 	extra_options["filter-current"]=$(tmux_option_or_fallback "@sessionx-filter-current" "true")
 	extra_options["custom-paths"]=$(tmux_option_or_fallback "@sessionx-custom-paths" "")
 	extra_options["custom-paths-subdirectories"]=$(tmux_option_or_fallback "@sessionx-custom-paths-subdirectories" "false")
+	extra_options["custom-paths-max-depth"]=$(tmux_option_or_fallback "@sessionx-custom-paths-max-depth" "1")
 	tmux set-option -g @sessionx-_built-extra-options "$(declare -p extra_options)"
 }
 


### PR DESCRIPTION
## Description
If custom paths subdirectories are set to true, you can set how deep the search for subdirectories should go

## Before
Searching subdirectories was defaulted to 1 with no options to set the max-depth value.

## After
An option can be set to specify how deep the subdirectory search can go.