### PR TITLE
fix: current session variable empty in header

### DIFF
--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -2,6 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$CURRENT_DIR/scripts"
+CURRENT="$(tmux display-message -p '#S')"
 
 source "$SCRIPTS_DIR/tmuxinator.sh"
 source "$SCRIPTS_DIR/fzf-marks.sh"


### PR DESCRIPTION
Fix: current session name missing in border label

This PR fixes a cosmetic issue where the border label displays
Current session: "" instead of the active tmux session name.

The $CURRENT variable was referenced in sessionx.tmux but never defined in that context.
It is now correctly set using:

CURRENT="$(tmux display-message -p '#S')"


This ensures the border label always shows the current session name.

Fixes #197 and #175.