### PR TITLE
fix: sort sessions by MRU using session_activity

### DIFF
--- a/scripts/reload_sessions.sh
+++ b/scripts/reload_sessions.sh
@@ -3,7 +3,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/git-branch.sh"
 
 CURRENT_SESSION=$(tmux display-message -p '#S')
-SESSIONS=$(tmux list-sessions | sed -E 's/:.*$//')
+SESSIONS=$(tmux list-sessions -F '#{session_activity} #{session_name}' | sort -t' ' -k1,1n | cut -d' ' -f2-)
 
 if [[ $(echo "$SESSIONS" | wc -l) -gt 1 ]]; then
 	SESSIONS=$(echo "$SESSIONS" | grep -v "$CURRENT_SESSION")

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -9,16 +9,13 @@ source "$CURRENT_DIR/fzf-marks.sh"
 source "$CURRENT_DIR/git-branch.sh"
 
 get_sorted_sessions() {
-	last_session=$(tmux display-message -p '#{client_last_session}')
-	sessions=$(tmux list-sessions | sed -E 's/:.*$//' | grep -Fxv "$last_session")
+	sessions=$(tmux list-sessions -F '#{session_activity} #{session_name}' | sort -t' ' -k1,1n | cut -d' ' -f2-)
 	filtered_sessions=$(tmux show-option -gqv @sessionx-_filtered-sessions)
 	if [[ -n "$filtered_sessions" ]]; then
 	  filtered_and_piped=$(echo "$filtered_sessions" | sed -E 's/,/|/g')
 	  sessions=$(echo "$sessions" | grep -Ev "$filtered_and_piped")
 	fi
-	local sorted
-	sorted=$(echo -e "$sessions\n$last_session" | awk '!seen[$0]++')
-	echo "$sorted"
+	echo "$sessions"
 }
 
 tmux_option_or_fallback() {

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -9,7 +9,7 @@ source "$CURRENT_DIR/fzf-marks.sh"
 source "$CURRENT_DIR/git-branch.sh"
 
 get_sorted_sessions() {
-	sessions=$(tmux list-sessions -F '#{session_activity} #{session_name}' | sort -t' ' -k1,1n | cut -d' ' -f2-)
+	sessions=$(tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort -t' ' -k1,1n | cut -d' ' -f2-)
 	filtered_sessions=$(tmux show-option -gqv @sessionx-_filtered-sessions)
 	if [[ -n "$filtered_sessions" ]]; then
 	  filtered_and_piped=$(echo "$filtered_sessions" | sed -E 's/,/|/g')

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -88,7 +88,7 @@ handle_args() {
 	SCROLL_DOWN="$bind_scroll_down:preview-half-page-down"
 
 	RENAME_SESSION_EXEC='bash -c '\'' printf >&2 "New name: ";read name; tmux rename-session -t {1} "${name}"; '\'''
-	RENAME_SESSION_RELOAD='bash -c '\'' tmux list-sessions | sed -E "s/:.*$//"; '\'''
+	RENAME_SESSION_RELOAD='bash -c '\'' tmux list-sessions -F "#{session_activity} #{session_name}" | sort -t" " -k1,1n | cut -d" " -f2-; '\'''
 	RENAME_SESSION="$bind_rename_session:execute($RENAME_SESSION_EXEC)+reload($RENAME_SESSION_RELOAD)"
 
 	HEADER="$bind_accept=󰿄  $bind_kill_session=󱂧  $bind_rename_session=󰑕  $bind_configuration_mode=󱃖  $bind_window_mode=   $bind_new_window=󰇘  $bind_back=󰌍  $bind_tree_mode=󰐆   $bind_scroll_up=  $bind_scroll_down= / $bind_zo="


### PR DESCRIPTION
## Summary

- Replace `client_last_session` hack (only tracked 1 previous session) with `#{session_activity}` timestamp sorting for full MRU ordering
- All three session-listing paths updated: initial load, kill-session reload, and rename-session reload
- Zero new dependencies — uses tmux's native `session_activity` format variable

## How it works

`tmux list-sessions -F '#{session_activity} #{session_name}'` returns a unix timestamp per session, updated whenever the user interacts with it. Sorting by this timestamp and stripping it gives true MRU order. Combined with the existing `--tac` flag in fzf, the most recently used session appears at the top.

## What stays the same

- `--tac` flag, layout, all keybinds
- `filtered-sessions` / `filter-current` options
- Preview, tmuxinator, fzf-marks, zoxide — all untouched
- No new options, no new files

## Test plan

- [ ] Open 4+ tmux sessions, switch A→B→C→D
- [ ] Open sessionx — D at top, then C, B, A
- [ ] Kill a session via sessionx — list reloads in MRU order
- [ ] Rename a session via sessionx — list reloads in MRU order
- [ ] `filter-current` and `filtered-sessions` options still work

Fixes #210