### PR TITLE
fix: use window_index in window mode reload to prevent preview errors

### DIFF
--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -72,7 +72,7 @@ handle_args() {
 
 	TREE_MODE="$bind_tree_mode:change-preview(${SCRIPTS_DIR%/}/preview.sh -t {1})"
 	CONFIGURATION_MODE="$bind_configuration_mode:reload(find -L $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d -o -type l)+change-preview($LS_COMMAND {})"
-	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(${SCRIPTS_DIR%/}/preview.sh -w {1})"
+	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}')+change-preview(${SCRIPTS_DIR%/}/preview.sh -w {1})"
 
 	NEW_WINDOW="$bind_new_window:reload(find -L $PWD -mindepth 1 -maxdepth 1 -type d -o -type l)+change-preview($LS_COMMAND {})"
 	ZO_WINDOW="$bind_zo:reload(zoxide query -l)+change-preview($LS_COMMAND {})"


### PR DESCRIPTION
## Summary

- Window mode (`Ctrl-w`) reload used `#{window_name}` to build the tmux target for the preview pane, but `capture-pane -t session:window_name` fails when multiple windows share the same name (common with `automatic-rename` or default shell names like "bash"/"zsh"), resulting in "can't find window" errors.
- Changed to use `#{window_index}` in the reload format (`session_name:window_index window_name`), which matches the initial load format already used in `sessionx.sh` line 36.

## Test plan

- Open tmux with multiple windows that have the same name (e.g., enable `automatic-rename` and open several windows in the same directory)
- Open sessionx (`prefix + s`) and press `Ctrl-w` to enter window mode
- Verify all windows show a preview without "can't find window" errors