### PR TITLE
fix: use window indexes when reloading window mode

### DIFF
--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -72,7 +72,7 @@ handle_args() {
 
 	TREE_MODE="$bind_tree_mode:change-preview(${SCRIPTS_DIR%/}/preview.sh -t {1})"
 	CONFIGURATION_MODE="$bind_configuration_mode:reload(find -L $CONFIGURATION_PATH -mindepth 1 -maxdepth 1 -type d -o -type l)+change-preview($LS_COMMAND {})"
-	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_name}')+change-preview(${SCRIPTS_DIR%/}/preview.sh -w {1})"
+	WINDOWS_MODE="$bind_window_mode:reload(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}')+change-preview(${SCRIPTS_DIR%/}/preview.sh -w {1})"
 
 	NEW_WINDOW="$bind_new_window:reload(find -L $PWD -mindepth 1 -maxdepth 1 -type d -o -type l)+change-preview($LS_COMMAND {})"
 	ZO_WINDOW="$bind_zo:reload(zoxide query -l)+change-preview($LS_COMMAND {})"


### PR DESCRIPTION
## Summary
- make the `Ctrl-w` reload format match the existing default window-mode format
- include `#{window_index}` in the reloaded list so selection targets stay unambiguous
- preserve window names in the UI while previewing/switching by numeric index

## Verification
- `bash -n sessionx.tmux scripts/*.sh`
- manual tmux smoke test with two windows named `alpha beta` and `alpha gamma`, confirming the new `session:index name` format resolves while the old name-only format becomes ambiguous (`can't find window: alpha`)
