### PR TITLE
fix: preserve spaces in session names when stripping git branch info

### DIFF
--- a/scripts/git-branch.sh
+++ b/scripts/git-branch.sh
@@ -47,5 +47,5 @@ format_sessions_with_git_branch() {
 strip_git_branch_info() {
 	local ESC
 	ESC=$(printf '\033')
-	echo "$1" | sed "s/${ESC}\[[0-9;]*m//g" | sed "s/[[:space:]]* .*//" | sed 's/[[:space:]]*$//'
+	echo "$1" | sed "s/${ESC}\[[0-9;]*m//g" | sed -E "s/[[:space:]]{2,}.*$//" | sed 's/[[:space:]]*$//'
 }


### PR DESCRIPTION
strip_git_branch_info truncated names at the first space because the sed pattern `s/[[:space:]]* .*//` matched a single space. Session names that contain spaces (e.g. "pose visualization") were reduced to their first word, causing the wrong/new session to be opened.

The git branch suffix is always separated by the printf padding of two or more spaces, so match `{2,}` whitespace instead, keeping single spaces in the session name intact.