### PR TITLE
feat: add @sessionx-sort option for most-recently-attached ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ set -g @sessionx-ls-command 'lsd --tree --color=always --icon=always'
 # Requires zoxide installed
 set -g @sessionx-zoxide-mode 'on'
 
+# Session ordering. 'default' keeps the current behaviour (last used session
+# pinned to the end). 'attached' orders every session by when it was last
+# attached, so your most recently used sessions stay together near the prompt.
+set -g @sessionx-sort 'attached'
+
 # If you want to pass in your own FZF options. This is passed in before all other
 # arguments to FZF to ensure that other options like `sessionx-pointer` and
 # `sessionx-window-height/width` still work. See `man fzf` for config options.

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -13,7 +13,9 @@ get_sorted_sessions() {
 
 	if [[ "$(tmux_option_or_fallback "@sessionx-sort" "default")" == "attached" ]]; then
 		# Order every session by when it was last attached (most recent last).
-		sessions=$(tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort -t' ' -k1,1n | cut -d' ' -f2-)
+		# Sort numerically on the leading timestamp, then strip it; keeps session
+		# names with spaces intact without depending on a fixed field delimiter.
+		sessions=$(tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort -n | sed 's/^[0-9]* //')
 		if [[ -n "$filtered_sessions" ]]; then
 		  filtered_and_piped=$(echo "$filtered_sessions" | sed -E 's/,/|/g')
 		  sessions=$(echo "$sessions" | grep -Ev "$filtered_and_piped")

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -9,9 +9,21 @@ source "$CURRENT_DIR/fzf-marks.sh"
 source "$CURRENT_DIR/git-branch.sh"
 
 get_sorted_sessions() {
+	filtered_sessions=$(tmux show-option -gqv @sessionx-_filtered-sessions)
+
+	if [[ "$(tmux_option_or_fallback "@sessionx-sort" "default")" == "attached" ]]; then
+		# Order every session by when it was last attached (most recent last).
+		sessions=$(tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort -t' ' -k1,1n | cut -d' ' -f2-)
+		if [[ -n "$filtered_sessions" ]]; then
+		  filtered_and_piped=$(echo "$filtered_sessions" | sed -E 's/,/|/g')
+		  sessions=$(echo "$sessions" | grep -Ev "$filtered_and_piped")
+		fi
+		echo "$sessions"
+		return
+	fi
+
 	last_session=$(tmux display-message -p '#{client_last_session}')
 	sessions=$(tmux list-sessions | sed -E 's/:.*$//' | grep -Fxv "$last_session")
-	filtered_sessions=$(tmux show-option -gqv @sessionx-_filtered-sessions)
 	if [[ -n "$filtered_sessions" ]]; then
 	  filtered_and_piped=$(echo "$filtered_sessions" | sed -E 's/,/|/g')
 	  sessions=$(echo "$sessions" | grep -Ev "$filtered_and_piped")


### PR DESCRIPTION
The session list is ordered alphabetically with the last-used session pinned to the end. When I bounce between a handful of projects I keep losing them in the list, since everything else stays alphabetical no matter how recently I was in it.

This adds an opt-in `@sessionx-sort` option:

```
set -g @sessionx-sort 'attached'
```

With `attached`, sessions are ordered by `session_last_attached`, so the ones you've touched most recently group together at the end (right by the prompt with the default reverse layout). Leaving it unset, or `default`, keeps the current behaviour exactly as-is.

I used `session_last_attached` rather than `session_activity` deliberately: activity gets bumped by background output, so a session running a build or a watcher drifts around the list without you ever switching to it. Last-attached only moves when you actually go to a session.

The default code path is unchanged, so this is a no-op unless you opt in.
