### PR TITLE
fix: name zoxide-created window after dir, not full path

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -106,7 +106,7 @@ handle_output() {
 		else
 			if [[ "$Z_MODE" == "on" ]]; then
 				z_target=$(zoxide query "$target")
-				tmux new-session -ds "$target" -c "$z_target" -n "$z_target"
+				tmux new-session -ds "$target" -c "$z_target" -n "$(basename "$z_target")"
 			else
 				tmux new-session -ds "$target"
 			fi


### PR DESCRIPTION
Hi! I use sessionx every day as my session picker with `@sessionx-zoxide-mode on`, and it's a lovely workflow.

When zoxide mode is on and I type a query that resolves to a directory (so a new session gets created there), the window is named with the full absolute path that `zoxide query` returns instead of the directory name. My status bar ends up showing `/home/dustin/projects/foo` where I'd expect just `foo`. The non-zoxide directory branch a few lines above already names the window after the basename (`basename "$target" | tr -d '.'`), so the zoxide branch is just inconsistent with the rest of the file.

What this changes:
- Pass `basename "$z_target"` to `new-session -n` in the zoxide branch, matching what the directory branch already does.

How to verify:
- `set -g @sessionx-zoxide-mode on`, then `zoxide add ~/projects/foo`
- Open sessionx, type a query that matches that dir so it creates a new session
- The new window's name is `foo`, not the absolute path

No change for existing sessions or for the non-zoxide paths. Happy to rework if you'd rather handle the naming a different way.
