### PR TITLE
feat: add @sessionx-tmuxinator-args option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ You may find that Nixpkgs does not have the latest updates of this plugin, this 
 #### In your flake.nix inputs
 
 ```nix
-
 inputs.tmux-sessionx.url = "github:omerxx/tmux-sessionx";
 
 # ...
@@ -91,7 +90,6 @@ nixosConfigurations."system-name" = nixpkgs.lib.nixosSystem {
 #### In your tmux.nix configuration or anywhere else in your configuration
 
 ```nix
-
 programs.tmux.plugins = [
   {
     # Need to change <system> to your aarch or use ${pkgs.system} to interpolate aarch
@@ -196,6 +194,10 @@ set -g @sessionx-legacy-fzf-support 'on'
 # and look for a tmuxinator project with that name.
 # If found, it'll launch the template using tmuxinator
 set -g @sessionx-tmuxinator-mode 'off'
+
+# Append args to `tmuxinator start` command
+# Can be used for example to pass `--suppress-tmux-version-warning` or other args to tmuxinator
+set -g @sessionx-tmuxinator-args ''
 
 # Turn on fzf-marks (default: off) mode to launch a new session from your marks
 set -g @sessionx-fzf-marks-mode 'off'

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -13,8 +13,8 @@ get_sorted_sessions() {
 	sessions=$(tmux list-sessions | sed -E 's/:.*$//' | grep -Fxv "$last_session")
 	filtered_sessions=$(tmux show-option -gqv @sessionx-_filtered-sessions)
 	if [[ -n "$filtered_sessions" ]]; then
-	  filtered_and_piped=$(echo "$filtered_sessions" | sed -E 's/,/|/g')
-	  sessions=$(echo "$sessions" | grep -Ev "$filtered_and_piped")
+		filtered_and_piped=$(echo "$filtered_sessions" | sed -E 's/,/|/g')
+		sessions=$(echo "$sessions" | grep -Ev "$filtered_and_piped")
 	fi
 	local sorted
 	sorted=$(echo -e "$sessions\n$last_session" | awk '!seen[$0]++')
@@ -59,7 +59,7 @@ additional_input() {
 		fi
 		add_path() {
 			local path=$1
-			if ! grep -q "$(basename "$path")" <<< "$sessions"; then
+			if ! grep -q "$(basename "$path")" <<<"$sessions"; then
 				echo "$path"
 			fi
 		}
@@ -75,7 +75,7 @@ handle_output() {
 		# except in unlikely and contrived situations (e.g.
 		# "/home/person/projects:0\ bash" could be a path on your filesystem.)
 		target=$(echo "$@" | tr -d '\n')
-	elif is_fzf-marks_mark "$@" ; then
+	elif is_fzf-marks_mark "$@"; then
 		# Needs to run before session name mode
 		mark=$(get_fzf-marks_mark "$@")
 		target=$(get_fzf-marks_target "$@")
@@ -95,7 +95,7 @@ handle_output() {
 
 	if ! tmux has-session -t="$target" 2>/dev/null; then
 		if is_tmuxinator_enabled && is_tmuxinator_template "$target"; then
-			tmuxinator start "$target"
+			tmuxinator start "$target" "$(tmux show-option -gqv @sessionx-tmuxinator-args)"
 		elif test -n "$mark"; then
 			tmux new-session -ds "$mark" -c "$target"
 			target="$mark"


### PR DESCRIPTION
Small PR to enable passing args to `tmuxinator start` with the @sessionx-tmuxinator-args tmux option. This is useful to pass something like `--suppress-tmux-version-warning` to `tmuxinator`.

I left the default value as an empty string, so it won't take effect unless someone explicitly sets it in their config.